### PR TITLE
Ensure member list uses configured spreadsheet

### DIFF
--- a/コード.js
+++ b/コード.js
@@ -519,8 +519,9 @@ function diagnoseUploadPath(){
 }
 /** 利用者一覧を取得（ほのぼのIDシートから） */
 function getMemberList() {
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
   const sh = ss.getSheetByName('ほのぼのID');
+  if (!sh) throw new Error('シート「ほのぼのID」が見つかりません');
   const vals = sh.getDataRange().getValues();
   const out = [];
 


### PR DESCRIPTION
## Summary
- update getMemberList to open the configured spreadsheet ID rather than relying on the active workbook
- align getMemberList with addMember by throwing a clear error when the "ほのぼのID" sheet is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca54c824f88321a4843dd9945fb4a5