### PR TITLE
Fix script syntax error blocking main view display

### DIFF
--- a/member.html
+++ b/member.html
@@ -642,7 +642,8 @@ function updateMediaGallery(records) {
     </div>`;
   }).join("");
   gallery.innerHTML = `<div class="media-grid">${cards}</div>`;
-  
+}
+
 // ===== 過去記録（編集・削除付き） =====
 function loadRecords(){
   const days=document.getElementById("recordRange").value;


### PR DESCRIPTION
## Summary
- add the missing closing brace to `updateMediaGallery` so the client script parses and runs again

## Testing
- not run (web app front-end only)


------
https://chatgpt.com/codex/tasks/task_e_68ccfc7998188321a2161a4d39132d28