### PR TITLE
Fix member search header normalization

### DIFF
--- a/member.html
+++ b/member.html
@@ -2449,4 +2449,4 @@ if(isExternalMode){
 }
 </script>
 </body>
-</html><- trigger real Claude run -->
+</html>

--- a/コード.js
+++ b/コード.js
@@ -235,8 +235,7 @@ function normalizeMemberId_(value) {
 
 function normalizeMemberHeaderLabel_(label) {
   if (label == null) return '';
-  return String(label)
-    .normalize('NFKC')
+  return toHiragana_(String(label))
     .replace(/[\s　]+/g, '')
     .replace(/[()（）]/g, '')
     .toLowerCase();
@@ -245,7 +244,9 @@ function normalizeMemberHeaderLabel_(label) {
 function findMemberSheetColumnIndex_(headerNormalized, candidates) {
   if (!Array.isArray(headerNormalized)) return -1;
   for (const candidate of candidates) {
-    const idx = headerNormalized.findIndex(label => label === candidate || label.includes(candidate));
+    const normalizedCandidate = normalizeMemberHeaderLabel_(candidate);
+    if (!normalizedCandidate) continue;
+    const idx = headerNormalized.findIndex(label => label === normalizedCandidate || label.includes(normalizedCandidate));
     if (idx >= 0) return idx;
   }
   return -1;


### PR DESCRIPTION
## Summary
- normalize sheet header matching by converting labels to hiragana before comparison
- ensure candidate names are normalized when locating columns so kana data is picked up for search
- remove the leftover debug marker from the HTML footer

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1409677cc8321ac64fd99ea0eb69c