### PR TITLE
Implement standalone external share view

### DIFF
--- a/member.html
+++ b/member.html
@@ -138,42 +138,6 @@ button:hover { opacity:0.9;}
 .share-item .tag-group { display:flex; flex-wrap:wrap; gap:6px; margin-top:6px; }
 .share-form .toolbar { gap:8px; }
 .share-attachments-all { font-size:0.82rem; display:flex; align-items:center; gap:6px; margin-bottom:6px; }
-.external-wrapper { max-width:800px; margin:0 auto; }
-.external-card { background:#fff; border-radius:16px; padding:20px; box-shadow:0 6px 24px rgba(25,118,210,0.16); margin-top:30px; }
-.external-header { display:flex; flex-direction:column; gap:6px; margin-bottom:16px; }
-.external-title { font-size:1.4rem; color:var(--brand); margin:0; }
-.external-member { font-size:1rem; color:#40566f; }
-.external-intro { font-size:0.92rem; color:#4f5b6c; line-height:1.6; background:#f1f7ff; padding:12px; border-radius:12px; border:1px solid #d3e4ff; }
-.external-alert { margin-top:12px; padding:10px; border-radius:10px; font-size:0.88rem; display:none; }
-.external-alert.error { background:#ffe4e4; color:#b71c1c; border:1px solid #f5b5b5; display:block; }
-.external-alert.warning { background:#fff7e0; color:#8d6e02; border:1px solid #f4d67a; display:block; }
-.external-auth { margin-top:16px; padding:16px; border-radius:12px; background:#f9fbff; border:1px solid #dfe8fb; }
-.external-auth label { font-size:0.85rem; color:#445; display:flex; flex-direction:column; gap:6px; }
-.external-auth input[type="password"] { padding:8px; border-radius:6px; border:1px solid #c1ceeb; font-size:0.95rem; }
-.external-auth button { margin-top:12px; }
-.external-records { margin-top:20px; display:flex; flex-direction:column; gap:14px; }
-.external-record { background:#f6f9ff; border:1px solid #d8e4ff; border-radius:12px; padding:14px; box-shadow:0 2px 6px rgba(25,118,210,0.08); }
-.external-record.latest { border-color:#7aa7ff; box-shadow:0 4px 14px rgba(25,118,210,0.18); position:relative; }
-.external-record.latest::before { content:"NEW"; position:absolute; top:12px; right:12px; background:#1f65d6; color:#fff; font-size:0.65rem; padding:2px 6px; border-radius:999px; letter-spacing:0.04em; }
-.external-record .meta { font-size:0.85rem; color:#386087; margin-bottom:6px; display:flex; gap:6px; flex-wrap:wrap; }
-.external-record .text { font-size:0.95rem; line-height:1.6; color:#223; white-space:pre-wrap; }
-.external-record .attachments { margin-top:10px; display:flex; flex-wrap:wrap; gap:8px; }
-.external-record .attachments a { padding:6px 10px; background:#fff; border-radius:999px; border:1px solid #b7cef5; color:#1a56a3; font-size:0.82rem; text-decoration:none; }
-.external-record .attachments a:hover { background:#e8f1ff; }
-.external-controls { margin:16px 0 8px; display:flex; flex-wrap:wrap; gap:10px; }
-.external-controls input[type="text"], .external-controls select { padding:8px 10px; border-radius:8px; border:1px solid #c1ceeb; font-size:0.85rem; background:#fff; }
-.external-controls input[type="text"] { flex:1; min-width:200px; }
-.external-search-status { font-size:0.78rem; color:#60708f; margin-bottom:8px; min-height:18px; }
-.external-footer { font-size:0.78rem; color:#718096; margin-top:24px; text-align:center; }
-.external-muted { font-size:0.85rem; color:#6b7b92; }
-.external-flags { display:flex; flex-wrap:wrap; gap:8px; font-size:0.75rem; }
-.external-badge { display:inline-flex; align-items:center; gap:4px; padding:4px 10px; border-radius:999px; background:#eff5ff; color:#1f3763; font-weight:600; }
-.external-badge.subtle { background:#eef2f8; color:#425169; }
-.external-badge.audience { background:#e4f3ff; color:#145c9f; }
-.external-intro { position:relative; }
-body.external-mode { background:#f0f4ff; }
-.external-mode #internalApp { display:none !important; }
-.external-mode #externalApp { display:block !important; }
 </style>
 </head>
 <body>
@@ -374,48 +338,6 @@ body.external-mode { background:#f0f4ff; }
   </div>
 </div>
 
-<div id="externalApp" style="display:none;">
-  <div class="external-wrapper">
-    <div class="external-card">
-      <div class="external-header">
-        <h1 class="external-title">モニタリング共有ビュー</h1>
-        <div class="external-flags">
-          <span class="external-badge">閲覧専用</span>
-          <span class="external-badge subtle">個人情報保護中</span>
-          <span class="external-badge audience" id="externalAudienceBadge">共有先を確認中…</span>
-        </div>
-        <div id="externalMember" class="external-member"></div>
-        <div id="externalExpiry" class="external-muted"></div>
-        <div id="externalRange" class="external-muted"></div>
-      </div>
-      <div id="externalIntro" class="external-intro">
-        大切なご家族や関係者の皆さまと状況を共有するためのページです。必要な情報だけをまとめていますので、安心してご覧ください。
-      </div>
-      <div id="externalAlert" class="external-alert"></div>
-      <div id="externalAuth" class="external-auth" style="display:none;">
-        <form id="externalAuthForm">
-          <label>閲覧パスワード
-            <input type="password" id="externalPassword" autocomplete="one-time-code" placeholder="パスワードを入力してください">
-          </label>
-          <button type="submit">表示する</button>
-          <div id="externalAuthStatus" class="external-muted" style="margin-top:8px;"></div>
-        </form>
-      </div>
-      <div class="external-controls">
-        <input type="text" id="externalSearch" placeholder="本文検索（マスク部分は検索対象外）">
-        <select id="externalSort">
-          <option value="desc" selected>日付が新しい順</option>
-          <option value="asc">日付が古い順</option>
-          <option value="kind">区分順</option>
-        </select>
-      </div>
-      <div id="externalSearchStatus" class="external-search-status"></div>
-      <div id="externalRecords" class="external-records"></div>
-      <div id="externalFooter" class="external-footer"></div>
-    </div>
-  </div>
-</div>
-
 <script>
 let memberId = null, memberName = "";
 let memberList = [];
@@ -424,8 +346,6 @@ let memberListLoading = false;
 let memberListLoaded = false;
 let recordsCache = [];
 const queryParams = new URLSearchParams(window.location.search);
-const externalToken = queryParams.get("shareId") || queryParams.get("share") || queryParams.get("token") || "";
-const isExternalMode = !!externalToken;
 const shareAudienceInfo = {
   family: {
     label: "家族向け共有",
@@ -467,10 +387,6 @@ const shareAudienceInfo = {
 const shareAudienceDefault = "family";
 const shareExpiryPresetDefault = "30";
 const shareRangeDefault = "30";
-let currentExternalShare = null;
-let externalRecordsCache = [];
-let externalLatestTimestamp = 0;
-let externalSearchTimer = null;
 
 function getAudienceInfo(audience){
   const key = String(audience || "").toLowerCase();
@@ -829,7 +745,6 @@ function getDashboardSectionDomId(label) {
 }
 
 function updateDashboardFilterQueryParams() {
-  if (isExternalMode) return;
   try {
     const params = new URLSearchParams(window.location.search);
     const filters = dashboardState && dashboardState.filters ? dashboardState.filters : {};
@@ -2024,7 +1939,6 @@ function collectAttachmentOptions(records){
 }
 
 function updateShareAttachmentOptions(records){
-  if(isExternalMode) return;
   const container=document.getElementById("shareAttachments");
   if(!container) return;
   const data=collectAttachmentOptions(typeof records!=='undefined'?records:recordsCache);
@@ -2049,7 +1963,6 @@ function updateShareAttachmentOptions(records){
 }
 
 function applyShareAllState(){
-  if(isExternalMode) return;
   const shareAll=document.getElementById("shareAttachmentAll");
   const container=document.getElementById("shareAttachments");
   if(!container) return;
@@ -2062,7 +1975,6 @@ function applyShareAllState(){
 }
 
 function applyShareExpiryPreset(){
-  if(isExternalMode) return;
   const preset=document.getElementById("shareExpiryPreset");
   const custom=document.getElementById("shareExpires");
   if(!preset || !custom) return;
@@ -2082,7 +1994,6 @@ function applyShareExpiryPreset(){
 }
 
 function setupShareUi(){
-  if(isExternalMode) return;
   const openBtn=document.getElementById("btnOpenShareForm");
   if(openBtn){
     openBtn.onclick=()=>toggleShareForm(true);
@@ -2111,7 +2022,6 @@ function setupShareUi(){
 }
 
 function toggleShareForm(open){
-  if(isExternalMode) return;
   const form=document.getElementById("shareForm");
   if(!form) return;
   shareFormOpen=!!open;
@@ -2144,7 +2054,6 @@ function toggleShareForm(open){
 function closeShareForm(){ toggleShareForm(false); }
 
 function resetShareListPlaceholder(){
-  if(isExternalMode) return;
   const list=document.getElementById("shareList");
   if(!list) return;
   list.classList.add("muted");
@@ -2152,7 +2061,6 @@ function resetShareListPlaceholder(){
 }
 
 function fetchExternalShareList(){
-  if(isExternalMode) return;
   const list=document.getElementById("shareList");
   if(!memberId){
     externalShares=[];
@@ -2182,7 +2090,6 @@ function fetchExternalShareList(){
 }
 
 function renderShareList(){
-  if(isExternalMode) return;
   const list=document.getElementById("shareList");
   if(!list) return;
   if(!externalShares.length){
@@ -2230,7 +2137,6 @@ function renderShareItem(share){
 }
 
 async function handleShareListClick(event){
-  if(isExternalMode) return;
   const btn=event.target.closest('[data-action]');
   if(!btn) return;
   const action=btn.dataset.action;
@@ -2278,7 +2184,6 @@ async function handleShareListClick(event){
 }
 
 function openSharePrintView(share){
-  if(isExternalMode) return;
   if(!share || !share.url){
     alert("共有URLが見つかりませんでした");
     return;
@@ -2336,7 +2241,6 @@ function openSharePrintView(share){
 }
 async function handleCreateShare(event){
   if(event) event.preventDefault();
-  if(isExternalMode) return;
   if(!memberId){ alert("利用者を選択してください"); return; }
   const status=document.getElementById("shareFormStatus");
   if(status) status.textContent="共有リンクを発行しています…";
@@ -2443,30 +2347,6 @@ function fallbackCopy(text){
   }
 }
 
-function setupExternalControls(){
-  const search=document.getElementById("externalSearch");
-  if(search){
-    search.addEventListener("input",()=>{
-      if(externalSearchTimer) clearTimeout(externalSearchTimer);
-      externalSearchTimer=setTimeout(()=>applyExternalFilters(currentExternalShare),160);
-    });
-  }
-  const sort=document.getElementById("externalSort");
-  if(sort){
-    sort.addEventListener("change",()=>applyExternalFilters(currentExternalShare));
-  }
-}
-
-function setupExternalAuth(){
-  const form=document.getElementById("externalAuthForm");
-  if(form){
-    form.addEventListener("submit",e=>{
-      e.preventDefault();
-      handleExternalAuthSubmit();
-    });
-  }
-}
-
 function initInternalApp(){
   document.body.classList.remove("external-mode");
   setupMemberUi();
@@ -2474,243 +2354,6 @@ function initInternalApp(){
   setupShareUi();
   resetShareListPlaceholder();
   loadDashboard();
-}
-
-function initExternalMode(){
-  document.body.classList.add("external-mode");
-  currentExternalShare=null;
-  setupExternalAuth();
-  setupExternalControls();
-  if(!externalToken){
-    showExternalAlert("error","共有リンクが見つかりません。管理者にお問い合わせください。");
-    return;
-  }
-  fetchExternalShareMeta();
-}
-
-function fetchExternalShareMeta(){
-  setExternalLoading("共有設定を確認しています…");
-  callGoogle("getExternalShareMeta", externalToken).then(res=>{
-    if(!res || res.status!=="success"){
-      const msg=res && res.message ? res.message : "共有情報を取得できませんでした";
-      showExternalAlert("error", msg);
-      setExternalLoading("");
-      return;
-    }
-    const share=res.share||{};
-    currentExternalShare=share;
-    updateExternalHeader(share);
-    setExternalIntro(share);
-    if(share.expired){
-      showExternalAlert("warning","この共有リンクは期限切れです。最新のリンクを発行してください。");
-      showExternalAuthForm(false);
-      setExternalLoading("この共有リンクは無効になっています。");
-      setExternalFooter(share);
-      return;
-    }
-    showExternalAlert("","");
-    if(share.requirePassword){
-      showExternalAuthForm(true);
-      setExternalLoading("パスワードを入力してください。");
-    }else{
-      showExternalAuthForm(false);
-      loadExternalShareData("");
-    }
-  }).catch(err=>{
-    const msg=err && err.message ? err.message : String(err);
-    showExternalAlert("error", msg);
-    setExternalLoading("");
-  });
-}
-
-function showExternalAuthForm(show){
-  const auth=document.getElementById("externalAuth");
-  if(auth) auth.style.display=show?"":"none";
-}
-
-function setExternalLoading(message){
-  const recordsEl=document.getElementById("externalRecords");
-  const statusEl=document.getElementById("externalSearchStatus");
-  if(!recordsEl) return;
-  if(message){
-    recordsEl.innerHTML=`<div class="external-muted">${escapeHtml(message)}</div>`;
-    if(statusEl) statusEl.textContent="";
-    externalRecordsCache=[];
-    externalLatestTimestamp=0;
-  }else if(!recordsEl.innerHTML.trim()){
-    recordsEl.innerHTML="";
-  }
-}
-
-function showExternalAlert(type,message){
-  const alertEl=document.getElementById("externalAlert");
-  if(!alertEl) return;
-  alertEl.textContent=message?message:"";
-  alertEl.classList.remove("error","warning");
-  if(!message){
-    alertEl.style.display="none";
-    return;
-  }
-  alertEl.style.display="block";
-  if(type==='error') alertEl.classList.add("error");
-  else if(type==='warning') alertEl.classList.add("warning");
-}
-
-function updateExternalHeader(share){
-  const info=getAudienceInfo(share && share.audience);
-  const memberEl=document.getElementById("externalMember");
-  if(memberEl){
-    const label=share.memberName?`${share.memberName}（ID: ${share.memberId}）`:`利用者ID: ${share.memberId}`;
-    memberEl.textContent=label;
-  }
-  const expiry=document.getElementById("externalExpiry");
-  if(expiry){
-    expiry.textContent=share.expiresAtText?`閲覧期限：${share.expiresAtText}`:"閲覧期限：設定なし";
-  }
-  const rangeEl=document.getElementById("externalRange");
-  if(rangeEl){
-    const label=share.rangeLabel?`共有範囲：${share.rangeLabel}`:"共有範囲：直近30日";
-    rangeEl.textContent=label;
-  }
-  const badge=document.getElementById("externalAudienceBadge");
-  if(badge){
-    badge.textContent=info.label;
-  }
-}
-
-function setExternalFooter(share){
-  const footer=document.getElementById("externalFooter");
-  if(!footer) return;
-  const info=getAudienceInfo(share && share.audience);
-  const passwordMsg=share.requirePassword?"このページはパスワードで保護されています。":"このページはURLのみで閲覧できます。";
-  const caution=share.expired
-    ? "※ このリンクは期限切れです。新しいURLを受け取っていない場合は発行元へご連絡ください。"
-    : "※ このページのURLやパスワードは第三者に共有しないようご注意ください。";
-  const rangeMsg=share && share.rangeLabel ? `共有範囲：${share.rangeLabel}` : "共有範囲：直近30日";
-  footer.innerHTML=`${escapeHtml(info.label)} ｜ ${escapeHtml(passwordMsg)} ｜ ${escapeHtml(rangeMsg)}<br>${escapeHtml(caution)}`;
-}
-
-function setExternalIntro(share){
-  const intro=document.getElementById("externalIntro");
-  if(!intro) return;
-  const info=getAudienceInfo(share && share.audience);
-  const passwordMsg=share && share.requirePassword
-    ? "閲覧には共有されたパスワードの入力が必要です。"
-    : "閲覧にはパスワード入力は必要ありません。";
-  const rangeMsg=share && share.rangeLabel ? `共有範囲：${share.rangeLabel}` : "共有範囲：直近30日";
-  intro.innerHTML=`${escapeHtml(info.intro)}<br><span class="external-muted">${escapeHtml(passwordMsg)} ｜ ${escapeHtml(rangeMsg)}</span>`;
-}
-
-function handleExternalAuthSubmit(){
-  const passwordInput=document.getElementById("externalPassword");
-  const status=document.getElementById("externalAuthStatus");
-  const password=passwordInput?passwordInput.value:"";
-  if(status) status.textContent="確認中…";
-  loadExternalShareData(password).finally(()=>{
-    if(passwordInput) passwordInput.value="";
-  });
-}
-
-function loadExternalShareData(password){
-  setExternalLoading("記録を読み込んでいます…");
-  return callGoogle("enterExternalShare", externalToken, password||"").then(res=>{
-    const status=document.getElementById("externalAuthStatus");
-    if(!res || res.status!=="success"){
-      const msg=res && res.message ? res.message : "閲覧に失敗しました";
-      if(status) status.textContent=msg;
-      showExternalAuthForm(true);
-      setExternalLoading("");
-      return;
-    }
-    if(status) status.textContent="";
-    const share=res.share||{};
-    currentExternalShare=share;
-    updateExternalHeader(share);
-    setExternalIntro(share);
-    showExternalAuthForm(false);
-    showExternalAlert(share.expired?"warning":"", share.expired?"リンクの期限が切れています。再発行を依頼してください。":"");
-    renderExternalRecords(Array.isArray(res.records)?res.records:[], share);
-    setExternalFooter(share);
-  }).catch(err=>{
-    const status=document.getElementById("externalAuthStatus");
-    if(status) status.textContent=err && err.message ? err.message : "閲覧に失敗しました";
-    setExternalLoading("");
-  });
-}
-
-function renderExternalRecords(records, share){
-  externalRecordsCache=Array.isArray(records)?records.map(rec=>{
-    const timestamp=Number(rec.timestamp||0) || 0;
-    const textValue=String(rec.text||"");
-    const attachmentNames=Array.isArray(rec.attachments)?rec.attachments.map(att=>String(att && att.name || "")).join(" "):"";
-    const searchIndex=`${textValue} ${attachmentNames}`.toLowerCase();
-    return { ...rec, timestamp, searchIndex };
-  }):[];
-  externalLatestTimestamp=externalRecordsCache.reduce((max,rec)=>Math.max(max, Number(rec.timestamp||0)||0),0);
-  applyExternalFilters(share);
-}
-
-function applyExternalFilters(share){
-  const container=document.getElementById("externalRecords");
-  const statusEl=document.getElementById("externalSearchStatus");
-  if(!container) return;
-  if(!externalRecordsCache.length){
-    container.innerHTML='<div class="external-muted">共有可能な記録はまだありません。</div>';
-    if(statusEl) statusEl.textContent="";
-    return;
-  }
-  const searchInput=document.getElementById("externalSearch");
-  const sortSelect=document.getElementById("externalSort");
-  const query=searchInput ? searchInput.value.trim() : "";
-  const sortKey=sortSelect ? sortSelect.value : "desc";
-  let filtered=externalRecordsCache.slice();
-  if(query){
-    const q=query.toLowerCase();
-    filtered=filtered.filter(rec=>rec.searchIndex.includes(q));
-  }
-  const compareDesc=(a,b)=>(Number(b.timestamp||0)||0)-(Number(a.timestamp||0)||0);
-  if(sortKey==="asc"){
-    filtered.sort((a,b)=>(Number(a.timestamp||0)||0)-(Number(b.timestamp||0)||0));
-  }else if(sortKey==="kind"){
-    filtered.sort((a,b)=>{
-      const diff=String(a.kind||"").localeCompare(String(b.kind||""),"ja");
-      if(diff!==0) return diff;
-      return compareDesc(a,b);
-    });
-  }else{
-    filtered.sort(compareDesc);
-  }
-  container.innerHTML=filtered.length
-    ? filtered.map(rec=>buildExternalRecordHtml(rec, share)).join("\n")
-    : '<div class="external-muted">該当する記録はありません。</div>';
-  if(statusEl){
-    const total=externalRecordsCache.length;
-    if(!filtered.length){
-      statusEl.textContent=query?`0件表示（全${total}件中） ｜ キーワード「${query}」`:`0件表示`;
-    }else{
-      const base=filtered.length===total?`${filtered.length}件表示`:`${filtered.length}件表示（全${total}件中）`;
-      statusEl.textContent=query?`${base} ｜ キーワード「${query}」`:base;
-    }
-  }
-}
-
-function buildExternalRecordHtml(rec, share){
-  const showKind=(share && share.audience) ? (share.audience !== 'family') : true;
-  const text=escapeHtml(rec.text||"").replace(/\n/g,"<br>") || '<span class="external-muted">（本文なし）</span>';
-  const attachments=Array.isArray(rec.attachments)?rec.attachments:[];
-  const attachmentsHtml=attachments.length?`<div class="attachments">${attachments.map(att=>`<a href="${escapeHtml(att.url||'#')}" target="_blank" rel="noopener">📎 ${escapeHtml(att.name||'添付ファイル')}</a>`).join('')}</div>`:"";
-  const metaParts=[`<span>${escapeHtml(rec.dateText||'---')}</span>`];
-  if(showKind){
-    metaParts.push(`<span>${escapeHtml(rec.kind||'種別未設定')}</span>`);
-  }
-  const classes=(externalLatestTimestamp && Number(rec.timestamp||0)===externalLatestTimestamp)
-    ? "external-record latest"
-    : "external-record";
-  return `<div class="${classes}">`
-    + `<div class="meta">${metaParts.join('')}</div>`
-    + `<div class="text">${text}</div>`
-    + attachmentsHtml
-    + `</div>`;
 }
 
 function runAfterDomReady(fn){
@@ -2722,13 +2365,9 @@ function runAfterDomReady(fn){
 }
 
 runAfterDomReady(()=>{
-  if(isExternalMode){
-    initExternalMode();
-  }else{
-    refreshMemberList();
-    setupSearchBox();
-    initInternalApp();
-  }
+  refreshMemberList();
+  setupSearchBox();
+  initInternalApp();
 });
 </script>
 </body>

--- a/share.html
+++ b/share.html
@@ -1,0 +1,651 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>モニタリング共有ビュー</title>
+<style>
+:root {
+  --fg:#1f2a44; --bg:#eef3fb; --card:#ffffff; --accent:#2b6cb0; --muted:#5a6a85;
+  --border:#d6e2f5; --highlight:#ffe082; --alert:#d32f2f; --warning:#f59e0b;
+}
+* { box-sizing:border-box; }
+body { margin:0; font-family:"Noto Sans JP",system-ui,sans-serif; background:var(--bg); color:var(--fg); }
+.share-app { max-width:840px; margin:0 auto; padding:28px 18px 48px; }
+.share-header { background:var(--card); border-radius:20px; padding:22px; box-shadow:0 12px 30px rgba(24,72,140,0.12); }
+.share-heading { display:flex; flex-direction:column; gap:10px; }
+.share-title { margin:0; font-size:1.6rem; color:var(--accent); }
+.share-badges { display:flex; flex-wrap:wrap; gap:8px; }
+.badge { display:inline-flex; align-items:center; gap:6px; padding:4px 12px; border-radius:999px; font-size:0.78rem; background:#e3f2fd; color:#134b93; font-weight:600; }
+.badge.subtle { background:#edf2f9; color:#4a5a75; }
+.badge.audience { background:#dbeafe; color:#1d4ed8; }
+.share-member { font-size:1.05rem; font-weight:600; }
+.share-meta { margin-top:10px; display:flex; flex-wrap:wrap; gap:10px; font-size:0.82rem; color:var(--muted); }
+.share-meta .meta-item { display:inline-flex; align-items:center; gap:4px; }
+.share-intro { margin-top:18px; background:rgba(59,130,246,0.1); border:1px solid rgba(59,130,246,0.25); border-radius:16px; padding:16px 18px; line-height:1.6; font-size:0.93rem; color:#2c4674; }
+.share-alert { margin-top:18px; padding:14px; border-radius:14px; font-size:0.9rem; display:none; }
+.share-alert.error { display:block; background:#fde8e8; border:1px solid #f5b5b5; color:#b91c1c; }
+.share-alert.warning { display:block; background:#fff8e1; border:1px solid #f6d481; color:#9a6404; }
+.share-auth { margin-top:18px; background:var(--card); border-radius:16px; padding:18px; border:1px solid var(--border); box-shadow:0 8px 22px rgba(24,72,140,0.08); }
+.share-auth label { display:flex; flex-direction:column; gap:6px; font-size:0.9rem; color:#284066; }
+.share-auth input[type="password"] { padding:10px 12px; border-radius:10px; border:1px solid var(--border); font-size:1rem; }
+.share-auth button { margin-top:12px; align-self:flex-start; padding:8px 14px; border-radius:999px; background:var(--accent); color:#fff; border:none; font-size:0.92rem; cursor:pointer; box-shadow:0 4px 12px rgba(43,108,176,0.25); }
+.share-auth button:hover { opacity:0.92; }
+.share-muted { font-size:0.8rem; color:var(--muted); margin-top:8px; }
+.share-filters { margin-top:24px; background:var(--card); border-radius:18px; padding:20px; border:1px solid var(--border); box-shadow:0 10px 24px rgba(24,72,140,0.08); display:flex; flex-direction:column; gap:12px; }
+.filter-row { display:flex; flex-wrap:wrap; gap:16px; }
+.filter { display:flex; flex-direction:column; gap:6px; font-size:0.82rem; color:#35507a; min-width:160px; }
+.filter input[type="text"], .filter input[type="date"], .filter select { padding:8px 10px; border-radius:10px; border:1px solid var(--border); font-size:0.88rem; background:#f8fbff; color:#1f2a44; }
+.quick-range { display:flex; flex-direction:column; gap:8px; }
+.range-chips { display:flex; gap:8px; flex-wrap:wrap; }
+.range-chip { padding:6px 12px; border-radius:999px; border:1px solid #c7d8f2; background:#f4f8ff; color:#1f3a6d; font-size:0.78rem; cursor:pointer; }
+.range-chip.active { background:var(--accent); color:#fff; border-color:var(--accent); box-shadow:0 4px 10px rgba(43,108,176,0.25); }
+.share-status { margin-top:12px; font-size:0.82rem; color:var(--muted); min-height:20px; }
+.share-records { margin-top:18px; display:flex; flex-direction:column; gap:14px; }
+.share-record { background:var(--card); border-radius:16px; padding:18px; border:1px solid rgba(43,108,176,0.12); box-shadow:0 8px 20px rgba(24,72,140,0.08); }
+.share-record.latest { border-color:#7aa7ff; box-shadow:0 14px 28px rgba(24,72,140,0.18); position:relative; }
+.share-record.latest::before { content:"最新"; position:absolute; top:14px; right:16px; background:var(--accent); color:#fff; font-size:0.7rem; padding:2px 8px; border-radius:999px; letter-spacing:0.04em; }
+.record-meta { font-size:0.85rem; color:#3a5684; display:flex; flex-wrap:wrap; gap:10px; margin-bottom:10px; }
+.record-text { font-size:0.95rem; line-height:1.7; color:#1f2a44; white-space:pre-wrap; word-break:break-word; }
+.keyword-hit { background:var(--highlight); padding:0 4px; border-radius:4px; font-weight:600; }
+.keyword-hit.health { background:#ffe4e6; color:#b91c1c; }
+.keyword-hit.alert { background:#fde68a; color:#92400e; }
+.keyword-hit.new { background:#e0f2f1; color:#047857; }
+.record-attachments { margin-top:12px; display:flex; flex-wrap:wrap; gap:8px; }
+.record-attachments a { padding:6px 12px; border-radius:12px; background:#eef4ff; color:#1a56a3; font-size:0.82rem; text-decoration:none; }
+.record-attachments a:hover { background:#d9e6ff; }
+.empty-state { margin-top:28px; text-align:center; color:var(--muted); font-size:0.9rem; }
+.load-more { margin:12px auto 0; display:none; padding:10px 22px; border-radius:999px; border:none; background:var(--accent); color:#fff; font-size:0.9rem; cursor:pointer; box-shadow:0 8px 18px rgba(43,108,176,0.26); }
+.load-more:hover { opacity:0.92; }
+.share-footer { margin-top:40px; font-size:0.8rem; color:var(--muted); text-align:center; line-height:1.6; }
+.share-footer ul { margin:10px auto 0; padding-left:20px; text-align:left; max-width:560px; }
+.share-footer li { margin-bottom:6px; }
+.keyword-legend { display:flex; gap:8px; flex-wrap:wrap; margin-top:12px; font-size:0.78rem; color:#4a5a75; }
+.keyword-legend span { display:inline-flex; align-items:center; gap:4px; padding:4px 8px; border-radius:8px; background:#f1f5ff; }
+@media (max-width:640px){
+  .share-app { padding:18px 14px 36px; }
+  .share-header { padding:18px; }
+  .filter-row { flex-direction:column; }
+  .filter { width:100%; }
+  .quick-range { flex-direction:column; }
+}
+</style>
+</head>
+<body>
+<div class="share-app" id="shareApp">
+  <header class="share-header">
+    <div class="share-heading">
+      <h1 class="share-title">モニタリング共有ビュー</h1>
+      <div class="share-badges">
+        <span class="badge">閲覧専用</span>
+        <span class="badge subtle">個人情報は必要最小限のみ表示</span>
+        <span class="badge audience" id="shareAudienceBadge">共有先を確認中…</span>
+      </div>
+    </div>
+    <div class="share-member" id="shareMember">閲覧対象を確認しています…</div>
+    <div class="share-meta">
+      <span class="meta-item" id="shareRange">表示範囲を確認しています…</span>
+      <span class="meta-item" id="shareExpiry"></span>
+      <span class="meta-item" id="shareRemaining"></span>
+      <span class="meta-item" id="shareMask"></span>
+      <span class="meta-item" id="shareAttachmentPolicy"></span>
+    </div>
+  </header>
+  <section id="shareIntro" class="share-intro">
+    共有いただいたモニタリング記録を安全に閲覧できるページです。最新の様子を時系列で確認できます。
+  </section>
+  <div id="shareAlert" class="share-alert"></div>
+  <section id="shareAuth" class="share-auth" style="display:none;">
+    <form id="authForm">
+      <label>閲覧パスワード
+        <input type="password" id="authPassword" autocomplete="one-time-code" placeholder="パスワードを入力してください">
+      </label>
+      <button type="submit">記録を表示</button>
+      <div id="authStatus" class="share-muted"></div>
+    </form>
+  </section>
+  <section id="shareFilters" class="share-filters" style="display:none;">
+    <div class="filter-row">
+      <label class="filter" style="flex:1; min-width:220px;">
+        キーワード検索
+        <input type="text" id="filterSearch" placeholder="本文・添付名で検索">
+      </label>
+      <label class="filter">
+        種別
+        <select id="filterKind">
+          <option value="all">すべて</option>
+        </select>
+      </label>
+      <label class="filter">
+        表示順
+        <select id="filterSort">
+          <option value="desc" selected>日付が新しい順</option>
+          <option value="asc">日付が古い順</option>
+          <option value="kind">区分順</option>
+        </select>
+      </label>
+    </div>
+    <div class="filter-row">
+      <label class="filter">
+        表示期間（開始）
+        <input type="date" id="filterFrom">
+      </label>
+      <label class="filter">
+        表示期間（終了）
+        <input type="date" id="filterTo">
+      </label>
+      <div class="filter quick-range" style="flex:1;">
+        <span>クイック選択</span>
+        <div class="range-chips" id="rangeChips">
+          <button type="button" class="range-chip" data-range="7">直近7日</button>
+          <button type="button" class="range-chip" data-range="30">直近30日</button>
+          <button type="button" class="range-chip" data-range="90">直近90日</button>
+          <button type="button" class="range-chip" data-range="all">全期間</button>
+        </div>
+      </div>
+    </div>
+    <div class="keyword-legend">
+      <span><span class="keyword-hit health">体調変化</span> などの重要ワードを自動で色付けします</span>
+      <span><span class="keyword-hit new">新規追加</span> などの新着キーワードも強調表示します</span>
+    </div>
+  </section>
+  <div id="shareStatus" class="share-status"></div>
+  <div id="recordsContainer" class="share-records"></div>
+  <div id="emptyState" class="empty-state" style="display:none;">共有可能な記録はまだありません。</div>
+  <button id="loadMore" class="load-more">さらに表示</button>
+  <footer class="share-footer" id="shareFooter">
+    閲覧方法や期限についてご不明な点がありましたら、担当のケアマネジャーまでご連絡ください。
+  </footer>
+</div>
+<script>
+const TEMPLATE_TOKEN = <?= typeof shareToken === 'string' ? JSON.stringify(shareToken) : '""' ?>;
+const queryParams = new URLSearchParams(window.location.search);
+const externalToken = TEMPLATE_TOKEN || queryParams.get('shareId') || queryParams.get('share') || queryParams.get('token') || '';
+const shareAudienceInfo = {
+  family: {
+    label: '家族向け共有',
+    description: '日々の様子をわかりやすくまとめています。',
+    intro: '大切なご家族の近況を共有する専用ページです。安心してご覧ください。',
+    manualTips: [
+      'QRコードからアクセスし、最新の記録を順番に確認できます。',
+      '気になる点がありましたら担当ケアマネジャーへご連絡ください。'
+    ]
+  },
+  center: {
+    label: '地域包括支援センター向け共有',
+    description: '日付・区分付きで状況を把握できます。',
+    intro: '地域包括支援センターさまとの情報連携ページです。必要事項のみ抜粋しています。',
+    manualTips: [
+      '検索や期間フィルターで必要な記録を絞り込めます。',
+      '支援が必要な事項は担当ケアマネジャーまでお知らせください。'
+    ]
+  },
+  medical: {
+    label: '医療連携向け共有',
+    description: '体調変化を把握しやすい構成です。',
+    intro: '医療機関のみなさまとの共有ページです。経過の確認にお役立てください。',
+    manualTips: [
+      '強調表示されたワードから急ぎの情報を確認できます。',
+      '必要に応じて診察・訪問時の資料としてご活用ください。'
+    ]
+  },
+  service: {
+    label: 'サービス事業者向け共有',
+    description: '現場スタッフが把握しやすいように整理しています。',
+    intro: 'サービス提供事業者さま向けの共有ページです。日々のケアにご活用ください。',
+    manualTips: [
+      '本文検索や種別フィルターで必要な記録を抽出できます。',
+      '気づきや連絡事項は担当ケアマネジャーまで共有をお願いします。'
+    ]
+  }
+};
+const shareAudienceDefault = 'family';
+const KEYWORD_RULES = [
+  { pattern: '体調変化|発熱|発作|血圧|脈拍|食欲不振|倦怠感|転倒|怪我|受診', className: 'health' },
+  { pattern: '緊急|至急|要連絡|報告必須|注意', className: 'alert' },
+  { pattern: '新規追加|開始|導入|初回|更新', className: 'new' }
+];
+const DISPLAY_LIMIT_DEFAULT = 30;
+const DISPLAY_STEP = 30;
+const rangeButtons = [];
+let currentShare = null;
+let recordsCache = [];
+let filteredRecords = [];
+let displayLimit = DISPLAY_LIMIT_DEFAULT;
+let latestTimestamp = null;
+let searchTimer = null;
+
+function getAudienceInfo(audience){
+  const key = String(audience || '').toLowerCase();
+  return shareAudienceInfo[key] || shareAudienceInfo[shareAudienceDefault];
+}
+
+function escapeHtml(value){
+  const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return String(value ?? '').replace(/[&<>"']/g, ch => map[ch]);
+}
+
+function callGoogle(functionName, ...args){
+  return new Promise((resolve, reject) => {
+    try {
+      const runner = google.script.run.withSuccessHandler(resolve).withFailureHandler(err => reject(err));
+      runner[functionName](...args);
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+function setLoading(message){
+  const statusEl = document.getElementById('shareStatus');
+  const recordsEl = document.getElementById('recordsContainer');
+  const emptyEl = document.getElementById('emptyState');
+  if(statusEl) statusEl.textContent = message ? String(message) : '';
+  if(recordsEl) recordsEl.innerHTML = '';
+  if(emptyEl) emptyEl.style.display = 'none';
+  const loadMore = document.getElementById('loadMore');
+  if(loadMore) loadMore.style.display = 'none';
+}
+
+function showAlert(type, message){
+  const alertEl = document.getElementById('shareAlert');
+  if(!alertEl) return;
+  alertEl.className = 'share-alert' + (type ? ' ' + type : '');
+  alertEl.style.display = message ? 'block' : 'none';
+  alertEl.textContent = message || '';
+}
+
+function updateHeader(share){
+  const info = getAudienceInfo(share && share.audience);
+  const audienceBadge = document.getElementById('shareAudienceBadge');
+  if(audienceBadge) audienceBadge.textContent = info.label;
+  const memberEl = document.getElementById('shareMember');
+  if(memberEl){
+    memberEl.textContent = share && share.memberName ? `${share.memberName} 様のモニタリング` : '対象を確認しています…';
+  }
+  const rangeEl = document.getElementById('shareRange');
+  if(rangeEl){
+    const label = share && share.rangeLabel ? share.rangeLabel : '最新記録';
+    rangeEl.textContent = `表示範囲：${label}`;
+  }
+  const expiryEl = document.getElementById('shareExpiry');
+  if(expiryEl){
+    expiryEl.textContent = share && share.expiresAtText ? `閲覧期限：${share.expiresAtText}` : '閲覧期限：設定なし';
+  }
+  const remainingEl = document.getElementById('shareRemaining');
+  if(remainingEl){
+    remainingEl.textContent = share && share.remainingLabel ? share.remainingLabel : '';
+  }
+  const maskEl = document.getElementById('shareMask');
+  if(maskEl){
+    maskEl.textContent = share && share.maskMode === 'none' ? '本文：マスクなし' : '本文：個人情報を自動マスク';
+  }
+  const attachmentEl = document.getElementById('shareAttachmentPolicy');
+  if(attachmentEl){
+    const allowAll = share && share.allowAllAttachments;
+    const count = share && typeof share.allowedCount === 'number' ? share.allowedCount : 0;
+    attachmentEl.textContent = allowAll ? '添付：すべて閲覧可能' : `添付：${count}件のみ共有`;
+  }
+}
+
+function setIntro(share){
+  const info = getAudienceInfo(share && share.audience);
+  const introEl = document.getElementById('shareIntro');
+  if(!introEl) return;
+  const passwordMsg = share && share.requirePassword ? 'パスワード入力後に閲覧できます。' : 'パスワード入力は不要です。';
+  const rangeMsg = share && share.rangeLabel ? `${share.rangeLabel}の記録を表示中です。` : '最新の記録を表示中です。';
+  introEl.innerHTML = `${escapeHtml(info.intro)}<br><span class="share-muted">${escapeHtml(passwordMsg)} ${escapeHtml(rangeMsg)}</span>`;
+}
+
+function setFooter(share){
+  const footer = document.getElementById('shareFooter');
+  if(!footer) return;
+  const info = getAudienceInfo(share && share.audience);
+  const tips = Array.isArray(info.manualTips) ? info.manualTips : [];
+  footer.innerHTML = `閲覧方法や期限についてご不明な点がありましたら、担当のケアマネジャーまでご連絡ください。`;
+  if(tips.length){
+    footer.innerHTML += `<ul>${tips.map(t => `<li>${escapeHtml(t)}</li>`).join('')}</ul>`;
+  }
+}
+
+function decorateText(value){
+  let safe = escapeHtml(value || '');
+  KEYWORD_RULES.forEach(rule => {
+    const regex = new RegExp(rule.pattern, 'gi');
+    safe = safe.replace(regex, match => `<span class="keyword-hit ${rule.className}">${match}</span>`);
+  });
+  return safe.replace(/\n/g, '<br>');
+}
+
+function buildRecordHtml(record, showKind){
+  const metaParts = [];
+  metaParts.push(escapeHtml(record.dateText || '---'));
+  if(showKind){
+    metaParts.push(escapeHtml(record.kind || '種別未設定'));
+  }
+  const metaHtml = metaParts.map(part => `<span>${part}</span>`).join('<span>｜</span>');
+  const attachments = Array.isArray(record.attachments) ? record.attachments : [];
+  const attachmentsHtml = attachments.length
+    ? `<div class="record-attachments">${attachments.map(att => {
+        const name = escapeHtml(att && att.name ? att.name : '添付ファイル');
+        const url = escapeHtml(att && att.url ? att.url : '#');
+        return `<a href="${url}" target="_blank" rel="noopener">📎 ${name}</a>`;
+      }).join('')}</div>`
+    : '';
+  const classes = (latestTimestamp && Number(record.timestamp||0) === latestTimestamp)
+    ? 'share-record latest'
+    : 'share-record';
+  return `<article class="${classes}">
+    <div class="record-meta">${metaHtml}</div>
+    <div class="record-text">${decorateText(record.text || '') || '<span class="share-muted">（本文なし）</span>'}</div>
+    ${attachmentsHtml}
+  </article>`;
+}
+
+function updateKindOptions(){
+  const select = document.getElementById('filterKind');
+  if(!select) return;
+  const kinds = Array.from(new Set(recordsCache.map(rec => rec.kind).filter(Boolean))).sort((a,b) => String(a).localeCompare(String(b), 'ja'));
+  const current = select.value;
+  select.innerHTML = '<option value="all">すべて</option>' + kinds.map(kind => `<option value="${escapeHtml(kind)}">${escapeHtml(kind)}</option>`).join('');
+  if(kinds.includes(current)){
+    select.value = current;
+  }
+}
+
+function updateRangeButtons(active){
+  rangeButtons.forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.range === active);
+  });
+}
+
+function formatDateInput(ts){
+  if(!ts) return '';
+  const date = new Date(ts);
+  if(Number.isNaN(date.getTime())) return '';
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth()+1).padStart(2,'0');
+  const dd = String(date.getDate()).padStart(2,'0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function getDefaultQuickRange(share){
+  if(!share) return '30';
+  const label = String(share.rangeLabel || '').toLowerCase();
+  if(label.includes('全期間')) return 'all';
+  if(label.includes('90')) return '90';
+  if(label.includes('7')) return '7';
+  return '30';
+}
+
+function applyQuickRange(range){
+  const fromInput = document.getElementById('filterFrom');
+  const toInput = document.getElementById('filterTo');
+  updateRangeButtons(range);
+  if(range === 'all'){
+    if(fromInput) fromInput.value = '';
+    if(toInput) toInput.value = '';
+    applyFilters(true);
+    return;
+  }
+  const days = Number(range);
+  if(Number.isNaN(days)){
+    applyFilters(true);
+    return;
+  }
+  const endTs = latestTimestamp || Date.now();
+  const startTs = endTs - days * 24 * 3600 * 1000;
+  if(toInput) toInput.value = formatDateInput(endTs);
+  if(fromInput) fromInput.value = formatDateInput(startTs);
+  applyFilters(true);
+}
+
+function getFilterValues(){
+  const searchInput = document.getElementById('filterSearch');
+  const kindSelect = document.getElementById('filterKind');
+  const sortSelect = document.getElementById('filterSort');
+  const fromInput = document.getElementById('filterFrom');
+  const toInput = document.getElementById('filterTo');
+  const searchValue = searchInput ? searchInput.value.trim() : '';
+  const kindValue = kindSelect ? kindSelect.value : 'all';
+  const sortValue = sortSelect ? sortSelect.value : 'desc';
+  const fromValue = fromInput ? fromInput.value : '';
+  const toValue = toInput ? toInput.value : '';
+  const fromTime = fromValue ? new Date(fromValue + 'T00:00:00').getTime() : null;
+  const toTime = toValue ? new Date(toValue + 'T23:59:59').getTime() : null;
+  return { searchValue, kindValue, sortValue, fromTime, toTime };
+}
+
+function applyFilters(resetLimit){
+  if(resetLimit) displayLimit = DISPLAY_LIMIT_DEFAULT;
+  const { searchValue, kindValue, sortValue, fromTime, toTime } = getFilterValues();
+  let results = recordsCache.slice();
+  if(kindValue && kindValue !== 'all'){
+    results = results.filter(rec => String(rec.kind||'') === kindValue);
+  }
+  if(fromTime){
+    results = results.filter(rec => typeof rec.timestamp === 'number' ? rec.timestamp >= fromTime : true);
+  }
+  if(toTime){
+    results = results.filter(rec => typeof rec.timestamp === 'number' ? rec.timestamp <= toTime : true);
+  }
+  if(searchValue){
+    const lower = searchValue.toLowerCase();
+    results = results.filter(rec => rec.searchIndex.includes(lower));
+  }
+  const compareDesc = (a,b) => (Number(b.timestamp||0)||0) - (Number(a.timestamp||0)||0);
+  if(sortValue === 'asc'){
+    results.sort((a,b) => (Number(a.timestamp||0)||0) - (Number(b.timestamp||0)||0));
+  }else if(sortValue === 'kind'){
+    results.sort((a,b) => {
+      const diff = String(a.kind||'').localeCompare(String(b.kind||''), 'ja');
+      if(diff !== 0) return diff;
+      return compareDesc(a,b);
+    });
+  }else{
+    results.sort(compareDesc);
+  }
+  filteredRecords = results;
+  renderRecords();
+  updateStatus(searchValue);
+}
+
+function renderRecords(){
+  const container = document.getElementById('recordsContainer');
+  const emptyEl = document.getElementById('emptyState');
+  const loadMore = document.getElementById('loadMore');
+  if(!container) return;
+  if(!filteredRecords.length){
+    container.innerHTML = '';
+    if(emptyEl) emptyEl.style.display = 'block';
+    if(loadMore) loadMore.style.display = 'none';
+    return;
+  }
+  if(emptyEl) emptyEl.style.display = 'none';
+  const showKind = currentShare ? (currentShare.audience !== 'family') : true;
+  const items = filteredRecords.slice(0, displayLimit).map(rec => buildRecordHtml(rec, showKind)).join('\n');
+  container.innerHTML = items;
+  if(loadMore){
+    loadMore.style.display = filteredRecords.length > displayLimit ? 'block' : 'none';
+  }
+}
+
+function updateStatus(searchValue){
+  const statusEl = document.getElementById('shareStatus');
+  if(!statusEl) return;
+  if(!filteredRecords.length){
+    if(searchValue){
+      statusEl.textContent = `該当する記録はありません（キーワード「${searchValue}」）。`;
+    }else{
+      statusEl.textContent = '';
+    }
+    return;
+  }
+  const total = recordsCache.length;
+  const shown = Math.min(displayLimit, filteredRecords.length);
+  const base = filteredRecords.length === total ? `${filteredRecords.length}件表示` : `${shown}件表示（全${total}件中）`;
+  statusEl.textContent = searchValue ? `${base} ｜ キーワード「${searchValue}」` : base;
+}
+
+function handleSearchInput(){
+  if(searchTimer) clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => applyFilters(true), 180);
+}
+
+function handleLoadMore(){
+  displayLimit += DISPLAY_STEP;
+  renderRecords();
+  const searchInput = document.getElementById('filterSearch');
+  updateStatus(searchInput ? searchInput.value.trim() : '');
+}
+
+function prepareRangeButtons(){
+  const chips = document.querySelectorAll('#rangeChips .range-chip');
+  chips.forEach(btn => {
+    rangeButtons.push(btn);
+    btn.addEventListener('click', () => applyQuickRange(btn.dataset.range));
+  });
+}
+
+function normalizeRecords(records){
+  const audience = currentShare ? currentShare.audience : 'family';
+  return records.map(rec => {
+    const timestamp = Number(rec.timestamp || 0) || 0;
+    const textValue = String(rec.text || '');
+    const attachments = Array.isArray(rec.attachments) ? rec.attachments : [];
+    const attachmentNames = attachments.map(att => String(att && att.name || '')).join(' ');
+    const searchIndex = `${textValue} ${attachmentNames}`.toLowerCase();
+    return { ...rec, timestamp, searchIndex, audience };
+  });
+}
+
+function onAuthSubmit(event){
+  event.preventDefault();
+  const input = document.getElementById('authPassword');
+  const status = document.getElementById('authStatus');
+  const password = input ? input.value : '';
+  if(status) status.textContent = '照合中です…';
+  loadShareData(password).finally(() => {
+    if(input) input.value = '';
+  });
+}
+
+function fetchShareMeta(){
+  if(!externalToken){
+    showAlert('error', '共有リンクが見つかりません。担当のケアマネジャーにお問い合わせください。');
+    setLoading('共有リンクが無効です。');
+    return Promise.resolve(null);
+  }
+  setLoading('共有設定を確認しています…');
+  return callGoogle('getExternalShareMeta', externalToken).then(res => {
+    if(!res || res.status !== 'success'){
+      const msg = res && res.message ? res.message : '共有設定の取得に失敗しました。';
+      showAlert('error', msg);
+      setLoading('閲覧を開始できませんでした。');
+      return null;
+    }
+    const share = res.share || {};
+    currentShare = share;
+    updateHeader(share);
+    setIntro(share);
+    setFooter(share);
+    if(share.expired){
+      showAlert('warning', 'この共有リンクは期限切れです。最新のリンクを発行してください。');
+      setLoading('期限切れのため閲覧できません。');
+      return null;
+    }
+    showAlert('', '');
+    return share;
+  }).catch(err => {
+    const msg = err && err.message ? err.message : '共有設定の取得に失敗しました。';
+    showAlert('error', msg);
+    setLoading('閲覧を開始できませんでした。');
+    return null;
+  });
+}
+
+function loadShareData(password){
+  setLoading('記録を読み込んでいます…');
+  return callGoogle('enterExternalShare', externalToken, password || '').then(res => {
+    if(!res || res.status !== 'success'){
+      const msg = res && res.message ? res.message : '閲覧に失敗しました。';
+      showAlert('error', msg);
+      const status = document.getElementById('authStatus');
+      if(status) status.textContent = msg;
+      const auth = document.getElementById('shareAuth');
+      if(auth) auth.style.display = 'block';
+      setLoading('閲覧できませんでした。');
+      return;
+    }
+    const status = document.getElementById('authStatus');
+    if(status) status.textContent = '';
+    currentShare = res.share || currentShare;
+    updateHeader(currentShare);
+    setIntro(currentShare);
+    setFooter(currentShare);
+    const auth = document.getElementById('shareAuth');
+    if(auth) auth.style.display = 'none';
+    const filters = document.getElementById('shareFilters');
+    if(filters) filters.style.display = 'flex';
+    showAlert(currentShare.expired ? 'warning' : '', currentShare.expired ? 'リンクの期限が切れています。再発行を依頼してください。' : '');
+    recordsCache = normalizeRecords(Array.isArray(res.records) ? res.records : []);
+    latestTimestamp = recordsCache.reduce((max, rec) => Math.max(max, Number(rec.timestamp||0)||0), 0) || null;
+    updateKindOptions();
+    applyQuickRange(getDefaultQuickRange(currentShare));
+    if(!recordsCache.length){
+      setLoading('共有可能な記録はまだありません。');
+      const emptyEl = document.getElementById('emptyState');
+      if(emptyEl) emptyEl.style.display = 'block';
+      return;
+    }
+    applyFilters(true);
+  }).catch(err => {
+    const msg = err && err.message ? err.message : '閲覧に失敗しました。';
+    showAlert('error', msg);
+    const status = document.getElementById('authStatus');
+    if(status) status.textContent = msg;
+    setLoading('閲覧できませんでした。');
+  });
+}
+
+function initSharePage(){
+  if(!externalToken){
+    showAlert('error', '共有リンクが見つかりません。URLをご確認ください。');
+    return;
+  }
+  prepareRangeButtons();
+  const search = document.getElementById('filterSearch');
+  if(search) search.addEventListener('input', handleSearchInput);
+  const kind = document.getElementById('filterKind');
+  if(kind) kind.addEventListener('change', () => applyFilters(true));
+  const sort = document.getElementById('filterSort');
+  if(sort) sort.addEventListener('change', () => applyFilters(true));
+  const fromInput = document.getElementById('filterFrom');
+  if(fromInput) fromInput.addEventListener('change', () => { updateRangeButtons(''); applyFilters(true); });
+  const toInput = document.getElementById('filterTo');
+  if(toInput) toInput.addEventListener('change', () => { updateRangeButtons(''); applyFilters(true); });
+  const loadMore = document.getElementById('loadMore');
+  if(loadMore) loadMore.addEventListener('click', handleLoadMore);
+  const authForm = document.getElementById('authForm');
+  if(authForm) authForm.addEventListener('submit', onAuthSubmit);
+
+  fetchShareMeta().then(share => {
+    if(!share) return;
+    if(share.requirePassword){
+      const auth = document.getElementById('shareAuth');
+      if(auth) auth.style.display = 'block';
+      setLoading('パスワードを入力してください。');
+    }else{
+      loadShareData('');
+    }
+  });
+}
+
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', initSharePage);
+}else{
+  initSharePage();
+}
+</script>
+</body>
+</html>

--- a/コード.js
+++ b/コード.js
@@ -17,9 +17,16 @@ const DOC_TEMPLATE_ID_FAMILY_PROP = PropertiesService.getScriptProperties().getP
 
 /***** ── Webエントリ ───────────────────────────*****/
 function doGet(e) {
-  const tmpl = HtmlService.createTemplateFromFile('member'); // ファイル名: member.html
+  const params = (e && e.parameter) || {};
+  const shareToken = params.shareId || params.share || params.token || '';
+  const templateName = shareToken ? 'share' : 'member';
+  const tmpl = HtmlService.createTemplateFromFile(templateName);
+  if (shareToken) {
+    tmpl.shareToken = shareToken;
+  }
+  const title = shareToken ? 'モニタリング共有ビュー' : 'ケアマネ・モニタリング';
   return tmpl.evaluate()
-    .setTitle('ケアマネ・モニタリング')
+    .setTitle(title)
     .addMetaTag('viewport','width=device-width, initial-scale=1.0');
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `share.html` viewer with password gate, filters, quick range chips, and keyword highlighting for external shares
- switch `doGet` to pick the share template when a share token is supplied and set an appropriate page title
- simplify `member.html` so only the internal dashboard initializes now that the external view lives in its own template

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4d786eb5483218c80efe51f26f765