### PR TITLE
Switch share QR generation to data URLs and add printable view

### DIFF
--- a/member.html
+++ b/member.html
@@ -2004,8 +2004,9 @@ function renderShareItem(share){
   const accessLabel=share.accessCount?`閲覧回数: ${share.accessCount}回`:"";
   const metaParts=[audienceLabel,expiresLabel,attachmentsLabel,passwordLabel,maskLabel,rangeLabel,remaining,lastAccess,accessLabel].filter(Boolean);
   const metaHtml=metaParts.map(p=>`<span>${p}</span>`).join("\n");
-  const qrUrlRaw=share.qrUrl||"";
-  const qrUrl=qrUrlRaw|| (shareUrlRaw?`https://chart.googleapis.com/chart?cht=qr&chs=220x220&choe=UTF-8&chl=${encodeURIComponent(shareUrlRaw)}`:"");
+  const qrSrc=share.qrDataUrl||share.qrUrl||"";
+  const fallbackQr=!qrSrc && shareUrlRaw?`https://chart.googleapis.com/chart?cht=qr&chs=220x220&choe=UTF-8&chl=${encodeURIComponent(shareUrlRaw)}`:"";
+  const qrUrl=qrSrc||fallbackQr;
   const qrHtml=qrUrl?`<div class="share-qr"><img src="${qrUrl}" alt="共有QRコード"><div class="share-qr-actions"><div class="share-qr-url">${safeUrl}</div>`
     + `<div class="share-qr-buttons"><button class="secondary btn-compact" data-action="print-qr" data-token="${escapeHtml(share.token||'')}">QRコード・案内を印刷</button></div></div></div>`:"";
   const descriptionHtml=info.description?`<div class="share-meta-notes">${escapeHtml(info.description)}</div>`:"";
@@ -2075,58 +2076,13 @@ function openSharePrintView(share){
     alert("共有URLが見つかりませんでした");
     return;
   }
-  const info=getAudienceInfo(share.audience);
   const shareUrlRaw=share.url||"";
-  const qrUrlRaw=share.qrUrl||"";
-  const qrUrl=qrUrlRaw|| (shareUrlRaw?`https://chart.googleapis.com/chart?cht=qr&chs=260x260&choe=UTF-8&chl=${encodeURIComponent(shareUrlRaw)}`:"");
-  const expiryText=share.expiresAtText?`閲覧期限：${escapeHtml(share.expiresAtText)}`:"閲覧期限：設定なし";
-  const rangeText=share.rangeLabel?`共有範囲：${escapeHtml(share.rangeLabel)}`:"共有範囲：直近30日";
-  const passwordNote=share.passwordProtected?"閲覧時にパスワードが必要です。発行時にお伝えしたパスワードを入力してください。":"パスワード入力は不要です。";
-  const attachmentNote=share.allowAllAttachments?"添付ファイルもすべて閲覧できます。":(share.allowedCount?`選択した添付ファイル（${share.allowedCount}件）が閲覧できます。`:"本文のみが共有されています。");
-  const maskNote=share.maskMode==='simple'?"本文は固有名詞を一部マスキングしています。":"本文は原文のまま表示されます。";
-  const tips=(info.manualTips||[]).concat([passwordNote,attachmentNote,maskNote,"URLやパスワードは第三者に共有しないでください。"]);
-  const manualList=tips.map(t=>`<li>${escapeHtml(t)}</li>`).join("\n");
-  const win=window.open("","_blank");
+  const separator=shareUrlRaw.includes("?")?"&":"?";
+  const printUrl=`${shareUrlRaw}${separator}print=1`;
+  const win=window.open(printUrl,"_blank");
   if(!win){
     alert("ポップアップがブロックされました。ブラウザの設定をご確認ください。");
-    return;
   }
-  const html=`<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><title>${escapeHtml(info.label)}｜共有案内</title>
-<style>
-  body{font-family:'Noto Sans JP',system-ui,sans-serif;background:#f3f6ff;margin:0;padding:24px;}
-  @page{size:A4;margin:20mm;}
-  .sheet{max-width:720px;margin:0 auto;background:#fff;border-radius:18px;padding:28px;box-shadow:0 6px 24px rgba(25,118,210,0.18);}
-  .sheet h1{margin:0 0 12px;font-size:1.6rem;color:#1a3d78;}
-  .sheet .audience{font-size:1rem;color:#1f508b;margin-bottom:16px;font-weight:600;}
-  .sheet .row{display:flex;flex-wrap:wrap;gap:24px;align-items:center;margin-bottom:20px;}
-  .sheet .qr img{width:220px;height:220px;border:1px solid #d0ddf4;border-radius:16px;padding:10px;background:#fff;}
-  .sheet .details{flex:1;min-width:220px;font-size:0.95rem;color:#334;}
-  .sheet .details .url{word-break:break-all;margin:12px 0;padding:10px;border-radius:8px;border:1px dashed #c0d6f5;background:#f5f9ff;font-family:monospace;font-size:0.85rem;}
-  .sheet ol{margin:0 0 16px 18px;padding:0;font-size:0.92rem;color:#324;}
-  .sheet li{margin-bottom:8px;line-height:1.6;}
-  .sheet .footer{font-size:0.8rem;color:#5c6d86;border-top:1px solid #dbe6f8;padding-top:12px;text-align:right;}
-  .meta{font-size:0.85rem;color:#4a5c7a;margin-bottom:6px;}
-</style>
-</head><body>
-<div class="sheet">
-  <h1>モニタリング共有のご案内</h1>
-  <div class="audience">${escapeHtml(info.label)}</div>
-  <div class="row">
-    <div class="qr"><img src="${qrUrl}" alt="共有ページQRコード"></div>
-    <div class="details">
-      <p>${escapeHtml(info.description)}</p>
-      <div class="meta">${expiryText}<br>${rangeText}</div>
-      <div class="url">${escapeHtml(share.url)}</div>
-    </div>
-  </div>
-  <h2 style="font-size:1.1rem;color:#1f3763;margin:0 0 10px;">ご利用方法</h2>
-  <ol>${manualList}</ol>
-  <div class="footer">印刷日：${escapeHtml(formatDateTime(new Date()))}</div>
-</div>
-</body></html>`;
-  win.document.open();
-  win.document.write(html);
-  win.document.close();
 }
 async function handleCreateShare(event){
   if(event) event.preventDefault();

--- a/print.html
+++ b/print.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>モニタリング共有案内</title>
+<style>
+  body { font-family: "Noto Sans JP", system-ui, sans-serif; background:#f3f6ff; margin:0; padding:24px; }
+  @page { size:A4; margin:20mm; }
+  .sheet { max-width:720px; margin:0 auto; background:#fff; border-radius:18px; padding:28px; box-shadow:0 6px 24px rgba(25,118,210,0.18); }
+  .sheet h1 { margin:0 0 12px; font-size:1.6rem; color:#1a3d78; }
+  .sheet .audience { font-size:1rem; color:#1f508b; margin-bottom:16px; font-weight:600; }
+  .sheet .row { display:flex; flex-wrap:wrap; gap:24px; align-items:center; margin-bottom:20px; }
+  .sheet .qr { width:220px; height:220px; display:flex; align-items:center; justify-content:center; border:1px solid #d0ddf4; border-radius:16px; padding:10px; background:#fff; }
+  .sheet .qr img { width:100%; height:100%; object-fit:contain; }
+  .sheet .qr .qr-placeholder { text-align:center; font-size:0.85rem; color:#5c6d86; padding:12px; }
+  .sheet .details { flex:1; min-width:220px; font-size:0.95rem; color:#334; }
+  .sheet .details p { margin:0 0 12px; line-height:1.6; }
+  .sheet .details .meta { font-size:0.9rem; color:#4a5c7a; margin-bottom:12px; line-height:1.6; }
+  .sheet .details .url { word-break:break-all; margin:12px 0; padding:10px; border-radius:8px; border:1px dashed #c0d6f5; background:#f5f9ff; font-family:monospace; font-size:0.85rem; }
+  .sheet h2 { font-size:1.1rem; color:#1f3763; margin:24px 0 10px; }
+  .sheet ol { margin:0 0 16px 18px; padding:0; font-size:0.92rem; color:#324; }
+  .sheet li { margin-bottom:8px; line-height:1.6; }
+  .sheet .footer { font-size:0.8rem; color:#5c6d86; border-top:1px solid #dbe6f8; padding-top:12px; text-align:right; }
+  .error { max-width:520px; margin:80px auto; background:#fff5f5; color:#9a1e1e; border:1px solid #f2caca; border-radius:14px; padding:28px; font-size:0.95rem; }
+</style>
+</head>
+<body>
+<? var meta = typeof shareMeta !== 'undefined' ? shareMeta : null; ?>
+<? var share = (meta && meta.status === 'success') ? meta.share : null; ?>
+<? var info = typeof shareAudienceInfo !== 'undefined' ? shareAudienceInfo : null; ?>
+<? var tips = typeof shareManualTips !== 'undefined' ? shareManualTips : []; ?>
+<? var qrSrc = typeof shareQrSrc !== 'undefined' ? shareQrSrc : ''; ?>
+<? var printedAt = typeof printedAtText !== 'undefined' ? printedAtText : ''; ?>
+<? var errorMessage = (!share && meta && meta.message) ? meta.message : '共有情報を取得できませんでした。'; ?>
+<? if (share) { ?>
+<div class="sheet">
+  <h1>モニタリング共有のご案内</h1>
+  <div class="audience"><?!= info && info.label ? info.label : '共有案内' ?></div>
+  <div class="row">
+    <div class="qr">
+      <? if (qrSrc) { ?>
+        <img src="<?!= qrSrc ?>" alt="共有ページQRコード" />
+      <? } else { ?>
+        <div class="qr-placeholder">QRコードを生成できませんでした</div>
+      <? } ?>
+    </div>
+    <div class="details">
+      <? if (info && info.description) { ?><p><?!= info.description ?></p><? } ?>
+      <div class="meta">
+        <div>閲覧期限：<?!= share.expiresAtText ? share.expiresAtText : '設定なし' ?></div>
+        <div>共有範囲：<?!= share.rangeLabel ? share.rangeLabel : '直近30日' ?></div>
+        <div><?!= share.requirePassword ? '閲覧にはパスワードが必要です。' : 'パスワード入力は不要です。' ?></div>
+      </div>
+      <div class="url"><?!= share.url ?></div>
+      <div style="font-size:0.85rem; color:#4a5c7a;">添付：<?!= share.allowAllAttachments ? 'すべて閲覧可能' : (share.allowedCount ? share.allowedCount + '件のみ共有' : '本文のみ共有') ?></div>
+    </div>
+  </div>
+  <? if (tips && tips.length) { ?>
+  <h2>ご利用方法</h2>
+  <ol>
+    <? for (var i = 0; i < tips.length; i++) { ?>
+      <li><?!= tips[i] ?></li>
+    <? } ?>
+  </ol>
+  <? } ?>
+  <div class="footer">印刷日：<?!= printedAt ?></div>
+</div>
+<? } else { ?>
+<div class="error">
+  <p><?!= errorMessage ?></p>
+</div>
+<? } ?>
+<script>
+  window.addEventListener('load', function(){
+    try { window.print(); } catch (e) {}
+  });
+</script>
+</body>
+</html>

--- a/share.html
+++ b/share.html
@@ -591,13 +591,24 @@ function fetchShareMeta(){
     updateHeader(share);
     setIntro(share);
     setFooter(share);
+    let normalizedRecords = [];
+    if(!share.requirePassword){
+      normalizedRecords = normalizeRecords(Array.isArray(res.records) ? res.records : []);
+      recordsCache = normalizedRecords;
+      latestTimestamp = recordsCache.reduce((max, rec) => Math.max(max, Number(rec.timestamp||0)||0), 0) || null;
+      updateKindOptions();
+    }else{
+      recordsCache = [];
+      latestTimestamp = null;
+      updateKindOptions();
+    }
     if(share.expired){
       showAlert('warning', 'この共有リンクは期限切れです。最新のリンクを発行してください。');
       setLoading('期限切れのため閲覧できません。');
       return null;
     }
     showAlert('', '');
-    return share;
+    return { share, records: normalizedRecords };
   }).catch(err => {
     const msg = err && err.message ? err.message : '共有設定の取得に失敗しました。';
     showAlert('error', msg);
@@ -671,14 +682,36 @@ function initSharePage(){
   const authForm = document.getElementById('authForm');
   if(authForm) authForm.addEventListener('submit', onAuthSubmit);
 
-  fetchShareMeta().then(share => {
-    if(!share) return;
+  fetchShareMeta().then(result => {
+    if(!result) return;
+    const share = result.share || currentShare || {};
     if(share.requirePassword){
       const auth = document.getElementById('shareAuth');
       if(auth) auth.style.display = 'block';
       setLoading('パスワードを入力してください。');
+      return;
+    }
+    const filters = document.getElementById('shareFilters');
+    if(filters) filters.style.display = 'flex';
+    showAlert(share.expired ? 'warning' : '', share.expired ? 'リンクの期限が切れています。再発行を依頼してください。' : '');
+    if(share.expired){
+      setLoading('期限切れのため閲覧できません。');
+      return;
+    }
+    const initialRecords = Array.isArray(result.records) ? result.records : recordsCache;
+    if(initialRecords && initialRecords.length){
+      recordsCache = initialRecords;
+      latestTimestamp = recordsCache.reduce((max, rec) => Math.max(max, Number(rec.timestamp||0)||0), 0) || null;
+      updateKindOptions();
+      applyQuickRange(getDefaultQuickRange(share));
+      applyFilters(true);
     }else{
-      loadShareData('');
+      recordsCache = [];
+      latestTimestamp = null;
+      updateKindOptions();
+      setLoading('共有可能な記録はまだありません。');
+      const emptyEl = document.getElementById('emptyState');
+      if(emptyEl) emptyEl.style.display = 'block';
     }
   });
 }


### PR DESCRIPTION
## Summary
- generate external share QR codes with ChartApp, expose base64 data URLs in server responses, and reuse them throughout the workflow
- return share records from `getExternalShareMeta`, keep access logging for password-free links, and refresh the share page to render records immediately
- add a dedicated `print.html` template and update the management console to open the printable share view instead of constructing HTML in the browser

## Testing
- not run (Google Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6fb3d66d48321b0e4215f33e6af77