### PR TITLE
Limit external share view to single record and expand printing options

### DIFF
--- a/print.html
+++ b/print.html
@@ -3,72 +3,121 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>モニタリング共有案内</title>
+<title>モニタリング記録 印刷</title>
 <style>
-  body { font-family: "Noto Sans JP", system-ui, sans-serif; background:#f3f6ff; margin:0; padding:24px; }
-  @page { size:A4; margin:20mm; }
-  .sheet { max-width:720px; margin:0 auto; background:#fff; border-radius:18px; padding:28px; box-shadow:0 6px 24px rgba(25,118,210,0.18); }
-  .sheet h1 { margin:0 0 12px; font-size:1.6rem; color:#1a3d78; }
-  .sheet .audience { font-size:1rem; color:#1f508b; margin-bottom:16px; font-weight:600; }
-  .sheet .row { display:flex; flex-wrap:wrap; gap:24px; align-items:center; margin-bottom:20px; }
-  .sheet .qr { width:220px; height:220px; display:flex; align-items:center; justify-content:center; border:1px solid #d0ddf4; border-radius:16px; padding:10px; background:#fff; }
-  .sheet .qr img { width:100%; height:100%; object-fit:contain; }
-  .sheet .qr .qr-placeholder { text-align:center; font-size:0.85rem; color:#5c6d86; padding:12px; }
-  .sheet .details { flex:1; min-width:220px; font-size:0.95rem; color:#334; }
-  .sheet .details p { margin:0 0 12px; line-height:1.6; }
-  .sheet .details .meta { font-size:0.9rem; color:#4a5c7a; margin-bottom:12px; line-height:1.6; }
-  .sheet .details .url { word-break:break-all; margin:12px 0; padding:10px; border-radius:8px; border:1px dashed #c0d6f5; background:#f5f9ff; font-family:monospace; font-size:0.85rem; }
-  .sheet h2 { font-size:1.1rem; color:#1f3763; margin:24px 0 10px; }
-  .sheet ol { margin:0 0 16px 18px; padding:0; font-size:0.92rem; color:#324; }
-  .sheet li { margin-bottom:8px; line-height:1.6; }
-  .sheet .footer { font-size:0.8rem; color:#5c6d86; border-top:1px solid #dbe6f8; padding-top:12px; text-align:right; }
-  .error { max-width:520px; margin:80px auto; background:#fff5f5; color:#9a1e1e; border:1px solid #f2caca; border-radius:14px; padding:28px; font-size:0.95rem; }
+  body { font-family: "Noto Sans JP", system-ui, sans-serif; background:#f3f6ff; margin:0; padding:24px; color:#1f2a44; }
+  @page { size:A4; margin:15mm; }
+  .print-container { max-width:900px; margin:0 auto; }
+  .print-header { background:#fff; border-radius:20px; padding:26px; box-shadow:0 10px 34px rgba(25,118,210,0.18); }
+  .print-header h1 { margin:0; font-size:1.8rem; color:#1a3d78; }
+  .print-mode { margin-top:12px; font-size:0.95rem; color:#1f3763; font-weight:600; }
+  .print-context { margin-top:10px; display:flex; flex-wrap:wrap; gap:14px; font-size:0.92rem; color:#2f4b80; }
+  .print-meta { margin-top:10px; display:flex; flex-wrap:wrap; gap:12px; font-size:0.85rem; color:#4a5c7a; }
+  .print-body { margin-top:28px; display:flex; flex-direction:column; gap:24px; }
+  .print-record { background:#fff; border-radius:18px; padding:22px 24px; box-shadow:0 8px 24px rgba(45,100,180,0.12); page-break-inside:avoid; }
+  .print-record h2 { margin:0; font-size:1.25rem; color:#1f3763; }
+  .record-submeta { margin-top:8px; display:flex; flex-wrap:wrap; gap:10px; font-size:0.85rem; color:#4c5f82; }
+  .print-table { width:100%; border-collapse:collapse; margin-top:14px; font-size:0.92rem; }
+  .print-table th { width:28%; padding:8px 12px; text-align:left; background:#eef4ff; border-bottom:1px solid #d7e3f8; font-weight:600; vertical-align:top; }
+  .print-table td { padding:8px 12px; border-bottom:1px solid #e4ecfb; line-height:1.6; }
+  .attachment-list { margin:0; padding-left:18px; }
+  .attachment-list li { margin-bottom:4px; }
+  .print-footer { margin-top:30px; text-align:right; font-size:0.82rem; color:#5c6d86; }
+  .error { max-width:620px; margin:80px auto; background:#fff5f5; color:#9a1e1e; border:1px solid #f2caca; border-radius:16px; padding:28px; font-size:0.98rem; box-shadow:0 12px 28px rgba(185,28,28,0.16); }
 </style>
 </head>
 <body>
 <? var meta = typeof shareMeta !== 'undefined' ? shareMeta : null; ?>
 <? var share = (meta && meta.status === 'success') ? meta.share : null; ?>
-<? var info = typeof shareAudienceInfo !== 'undefined' ? shareAudienceInfo : null; ?>
-<? var tips = typeof shareManualTips !== 'undefined' ? shareManualTips : []; ?>
-<? var qrSrc = typeof shareQrSrc !== 'undefined' ? shareQrSrc : ''; ?>
+<? var records = Array.isArray(printRecords) ? printRecords : []; ?>
+<? var primary = typeof printPrimaryRecord !== 'undefined' ? printPrimaryRecord : null; ?>
+<? var mode = typeof printMode !== 'undefined' ? printMode : 'record'; ?>
+<? var center = typeof printCenter !== 'undefined' ? printCenter : ''; ?>
+<? var staff = typeof printStaff !== 'undefined' ? printStaff : ''; ?>
 <? var printedAt = typeof printedAtText !== 'undefined' ? printedAtText : ''; ?>
-<? var errorMessage = (!share && meta && meta.message) ? meta.message : '共有情報を取得できませんでした。'; ?>
-<? if (share) { ?>
-<div class="sheet">
-  <h1>モニタリング共有のご案内</h1>
-  <div class="audience"><?!= info && info.label ? info.label : '共有案内' ?></div>
-  <div class="row">
-    <div class="qr">
-      <? if (qrSrc) { ?>
-        <img src="<?!= qrSrc ?>" alt="共有ページQRコード" />
-      <? } else { ?>
-        <div class="qr-placeholder">QRコードを生成できませんでした</div>
-      <? } ?>
+<? var errorMessage = (typeof printErrorMessage !== 'undefined' && printErrorMessage) ? printErrorMessage : ''; ?>
+<? function esc(value) {
+     if (value == null) return '';
+     return String(value)
+       .replace(/&/g,'&amp;')
+       .replace(/</g,'&lt;')
+       .replace(/>/g,'&gt;')
+       .replace(/"/g,'&quot;')
+       .replace(/'/g,'&#39;');
+   }
+   function formatField(value) {
+     var safe = esc(value);
+     return safe.replace(/\r?\n/g,'<br>');
+   }
+   function audienceLabel(audience) {
+     var map = {
+       family: 'ご家族向け共有',
+       center: '地域包括支援センター向け共有',
+       medical: '医療連携向け共有',
+       service: 'サービス事業者向け共有'
+     };
+     return map[audience] || audience || '';
+   }
+?>
+<? var modeLabel = (mode === 'center') ? '地域包括支援センター全件' : (mode === 'staff' ? '担当者全件' : 'この記録のみ'); ?>
+<? if (records.length) { ?>
+<div class="print-container">
+  <header class="print-header">
+    <h1>モニタリング記録 印刷</h1>
+    <div class="print-mode">印刷対象：<?= esc(modeLabel) ?>（全<?= records.length ?>件）</div>
+    <div class="print-context">
+      <? if (primary && primary.memberName) { ?><span>対象利用者：<?= esc(primary.memberName) ?> 様</span><? } ?>
+      <? if (mode === 'center' && center) { ?><span>地域包括支援センター：<?= esc(center) ?></span><? } ?>
+      <? if (mode === 'staff' && staff) { ?><span>担当者：<?= esc(staff) ?></span><? } ?>
     </div>
-    <div class="details">
-      <? if (info && info.description) { ?><p><?!= info.description ?></p><? } ?>
-      <div class="meta">
-        <div>閲覧期限：<?!= share.expiresAtText ? share.expiresAtText : '設定なし' ?></div>
-        <div>共有範囲：<?!= share.rangeLabel ? share.rangeLabel : '直近30日' ?></div>
-        <div><?!= share.requirePassword ? '閲覧にはパスワードが必要です。' : 'パスワード入力は不要です。' ?></div>
-      </div>
-      <div class="url"><?!= share.url ?></div>
-      <div style="font-size:0.85rem; color:#4a5c7a;">添付：<?!= share.allowAllAttachments ? 'すべて閲覧可能' : (share.allowedCount ? share.allowedCount + '件のみ共有' : '本文のみ共有') ?></div>
+    <div class="print-meta">
+      <? if (share && share.rangeLabel) { ?><span>共有範囲：<?= esc(share.rangeLabel) ?></span><? } ?>
+      <? if (share) { ?><span>閲覧期限：<?= esc(share.expiresAtText || '設定なし') ?></span><? } ?>
+      <span>印刷日時：<?= esc(printedAt) ?></span>
     </div>
-  </div>
-  <? if (tips && tips.length) { ?>
-  <h2>ご利用方法</h2>
-  <ol>
-    <? for (var i = 0; i < tips.length; i++) { ?>
-      <li><?!= tips[i] ?></li>
-    <? } ?>
-  </ol>
-  <? } ?>
-  <div class="footer">印刷日：<?!= printedAt ?></div>
+  </header>
+  <main class="print-body">
+    <? records.forEach(function(record, index){ ?>
+      <section class="print-record">
+        <h2><?= esc(record.dateText || ('記録 ' + (index + 1))) ?></h2>
+        <div class="record-submeta">
+          <? if(record.kind){ ?><span>区分：<?= esc(record.kind) ?></span><? } ?>
+          <? if(record.memberName){ ?><span>利用者：<?= esc(record.memberName) ?> 様</span><? } ?>
+          <? if(record.center && mode !== 'center'){ ?><span>センター：<?= esc(record.center) ?></span><? } ?>
+          <? if(record.staff && mode !== 'staff'){ ?><span>担当：<?= esc(record.staff) ?></span><? } ?>
+          <? if(record.recordId){ ?><span>recordId：<?= esc(record.recordId) ?></span><? } ?>
+        </div>
+        <table class="print-table">
+          <? var fieldKeys = Object.keys(record.fields || {}); ?>
+          <? fieldKeys.forEach(function(key){
+               var value = record.fields[key];
+               if (value == null || value === '') return;
+               if (key === '添付') return;
+          ?>
+            <tr><th><?= esc(key) ?></th><td><?= formatField(value) ?></td></tr>
+          <? }); ?>
+          <? if (record.attachments && record.attachments.length) { ?>
+            <tr><th>添付ファイル</th><td>
+              <ul class="attachment-list">
+                <? record.attachments.forEach(function(att){ ?>
+                  <li><?= esc(att && att.name ? att.name : (att && att.url ? att.url : '添付ファイル')) ?></li>
+                <? }); ?>
+              </ul>
+            </td></tr>
+          <? } else if (record.fields && record.fields['添付']) { ?>
+            <tr><th>添付ファイル</th><td><?= formatField(record.fields['添付']) ?></td></tr>
+          <? } ?>
+        </table>
+      </section>
+    <? }); ?>
+  </main>
+  <footer class="print-footer">
+    <? if (share && share.audience) { ?><span>共有先：<?= esc(audienceLabel(share.audience)) ?></span> ｜ <? } ?>印刷日時：<?= esc(printedAt) ?>
+  </footer>
 </div>
 <? } else { ?>
 <div class="error">
-  <p><?!= errorMessage ?></p>
+  <p><?= esc(errorMessage || (meta && meta.message) || '印刷できる記録が見つかりませんでした。') ?></p>
 </div>
 <? } ?>
 <script>

--- a/share.html
+++ b/share.html
@@ -22,6 +22,13 @@ body { margin:0; font-family:"Noto Sans JP",system-ui,sans-serif; background:var
 .share-member { font-size:1.05rem; font-weight:600; }
 .share-meta { margin-top:10px; display:flex; flex-wrap:wrap; gap:10px; font-size:0.82rem; color:var(--muted); }
 .share-meta .meta-item { display:inline-flex; align-items:center; gap:4px; }
+.share-actions { margin-top:16px; display:flex; flex-wrap:wrap; gap:12px; align-items:flex-end; }
+.print-controls { display:flex; flex-wrap:wrap; gap:8px; align-items:flex-end; }
+.print-controls label { display:flex; flex-direction:column; gap:6px; font-size:0.82rem; color:#35507a; }
+.print-select { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background:#f8fbff; color:#1f2a44; font-size:0.9rem; min-width:200px; }
+.print-button { padding:10px 18px; border-radius:999px; border:none; background:var(--accent); color:#fff; font-size:0.92rem; cursor:pointer; box-shadow:0 8px 18px rgba(43,108,176,0.24); }
+.print-button:disabled { background:#a8c2e8; cursor:not-allowed; box-shadow:none; }
+.print-button:not(:disabled):hover { opacity:0.92; }
 .share-intro { margin-top:18px; background:rgba(59,130,246,0.1); border:1px solid rgba(59,130,246,0.25); border-radius:16px; padding:16px 18px; line-height:1.6; font-size:0.93rem; color:#2c4674; }
 .share-alert { margin-top:18px; padding:14px; border-radius:14px; font-size:0.9rem; display:none; }
 .share-alert.error { display:block; background:#fde8e8; border:1px solid #f5b5b5; color:#b91c1c; }
@@ -89,6 +96,18 @@ body { margin:0; font-family:"Noto Sans JP",system-ui,sans-serif; background:var
       <span class="meta-item" id="shareRemaining"></span>
       <span class="meta-item" id="shareMask"></span>
       <span class="meta-item" id="shareAttachmentPolicy"></span>
+    </div>
+    <div class="share-actions" id="printControls" style="display:none;">
+      <div class="print-controls">
+        <label>印刷対象
+          <select id="printScope" class="print-select">
+            <option value="record">この記録のみ</option>
+            <option value="center">地域包括支援センター全件</option>
+            <option value="staff">担当者全件</option>
+          </select>
+        </label>
+      </div>
+      <button type="button" class="print-button" id="printButton" disabled>印刷</button>
     </div>
   </header>
   <section id="shareIntro" class="share-intro">
@@ -159,8 +178,10 @@ body { margin:0; font-family:"Noto Sans JP",system-ui,sans-serif; background:var
 </div>
 <script>
 const TEMPLATE_TOKEN = <?= typeof shareToken === 'string' ? JSON.stringify(shareToken) : '""' ?>;
+const TEMPLATE_RECORD_ID = <?= typeof shareRecordId === 'string' ? JSON.stringify(shareRecordId) : '""' ?>;
 const queryParams = new URLSearchParams(window.location.search);
 const externalToken = TEMPLATE_TOKEN || queryParams.get('shareId') || queryParams.get('share') || queryParams.get('token') || '';
+const RECORD_ID_PARAM = TEMPLATE_RECORD_ID || queryParams.get('recordId') || queryParams.get('record') || '';
 const shareAudienceInfo = {
   family: {
     label: '家族向け共有',
@@ -214,6 +235,9 @@ let filteredRecords = [];
 let displayLimit = DISPLAY_LIMIT_DEFAULT;
 let latestTimestamp = null;
 let searchTimer = null;
+let resolvedRecordId = RECORD_ID_PARAM ? String(RECORD_ID_PARAM) : '';
+let primaryRecordData = null;
+let singleRecordMode = !!resolvedRecordId;
 
 function getAudienceInfo(audience){
   const key = String(audience || '').toLowerCase();
@@ -241,17 +265,20 @@ const EXEC_BASE_URL = window.location.href.split('#')[0].split('?')[0];
 async function callShareApi(action, options = {}){
   const token = options.token || externalToken;
   if (!token) throw new Error('共有リンクが見つかりません。');
+  const requestedRecordId = options.recordId !== undefined ? options.recordId : resolvedRecordId;
+  const recordIdValue = requestedRecordId ? String(requestedRecordId) : '';
   const canUseGoogleRun = typeof google !== 'undefined' && google.script && google.script.run;
   if (canUseGoogleRun) {
     if (action === 'meta') {
-      return callGoogle('getExternalShareMeta', token);
+      return callGoogle('getExternalShareMeta', token, recordIdValue || '');
     }
     if (action === 'enter') {
-      return callGoogle('enterExternalShare', token, options.password || '');
+      return callGoogle('enterExternalShare', token, options.password || '', recordIdValue || '');
     }
   }
   if (action === 'meta') {
     const params = new URLSearchParams({ shareApi: 'meta', shareId: token });
+    if (recordIdValue) params.set('recordId', recordIdValue);
     const res = await fetch(`${EXEC_BASE_URL}?${params.toString()}`, { credentials: 'include' });
     if (!res.ok) throw new Error('共有設定の取得に失敗しました。');
     try {
@@ -262,6 +289,7 @@ async function callShareApi(action, options = {}){
   }
   if (action === 'enter') {
     const body = new URLSearchParams({ action: 'shareEnter', shareId: token, password: options.password || '' });
+    if (recordIdValue) body.append('recordId', recordIdValue);
     const res = await fetch(EXEC_BASE_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
@@ -287,6 +315,7 @@ function setLoading(message){
   if(emptyEl) emptyEl.style.display = 'none';
   const loadMore = document.getElementById('loadMore');
   if(loadMore) loadMore.style.display = 'none';
+  updatePrintControls(null);
 }
 
 function showAlert(type, message){
@@ -348,6 +377,61 @@ function setFooter(share){
   if(tips.length){
     footer.innerHTML += `<ul>${tips.map(t => `<li>${escapeHtml(t)}</li>`).join('')}</ul>`;
   }
+}
+
+function updateFilterVisibility(){
+  const filters = document.getElementById('shareFilters');
+  if(!filters) return;
+  const shouldShow = !singleRecordMode && recordsCache.length > 1;
+  filters.style.display = shouldShow ? 'flex' : 'none';
+}
+
+function setSingleRecordMode(enabled){
+  singleRecordMode = !!enabled;
+  updateFilterVisibility();
+}
+
+function getResolvedRecordId(){
+  if(resolvedRecordId) return resolvedRecordId;
+  if(primaryRecordData && primaryRecordData.recordId) return String(primaryRecordData.recordId);
+  if(recordsCache.length && recordsCache[0].recordId) return String(recordsCache[0].recordId);
+  return '';
+}
+
+function updatePrintControls(record){
+  const container = document.getElementById('printControls');
+  const select = document.getElementById('printScope');
+  const button = document.getElementById('printButton');
+  if(!container || !select || !button) return;
+  if(!record){
+    container.style.display = 'none';
+    button.disabled = true;
+    return;
+  }
+  container.style.display = 'flex';
+  const hasCenter = !!String(record.center || '').trim();
+  const hasStaff = !!String(record.staff || '').trim();
+  const centerOption = select.querySelector('option[value="center"]');
+  const staffOption = select.querySelector('option[value="staff"]');
+  if(centerOption) centerOption.disabled = !hasCenter;
+  if(staffOption) staffOption.disabled = !hasStaff;
+  if(select.value === 'center' && !hasCenter) select.value = 'record';
+  if(select.value === 'staff' && !hasStaff) select.value = 'record';
+  button.disabled = false;
+}
+
+function handlePrintClick(){
+  const recordId = getResolvedRecordId();
+  if(!externalToken || !recordId){
+    showAlert('error', '印刷対象の記録を特定できません。');
+    return;
+  }
+  const select = document.getElementById('printScope');
+  const mode = select ? select.value : 'record';
+  const params = new URLSearchParams({ shareId: externalToken, print: '1', recordId });
+  if(mode && mode !== 'record') params.set('mode', mode);
+  const url = `${EXEC_BASE_URL}?${params.toString()}`;
+  window.open(url, '_blank', 'noopener');
 }
 
 function decorateText(value){
@@ -460,6 +544,13 @@ function getFilterValues(){
 
 function applyFilters(resetLimit){
   if(resetLimit) displayLimit = DISPLAY_LIMIT_DEFAULT;
+  if(singleRecordMode){
+    filteredRecords = recordsCache.slice();
+    displayLimit = filteredRecords.length;
+    renderRecords();
+    updateStatus('');
+    return;
+  }
   const { searchValue, kindValue, sortValue, fromTime, toTime } = getFilterValues();
   let results = recordsCache.slice();
   if(kindValue && kindValue !== 'all'){
@@ -515,6 +606,14 @@ function renderRecords(){
 function updateStatus(searchValue){
   const statusEl = document.getElementById('shareStatus');
   if(!statusEl) return;
+  if(singleRecordMode){
+    if(!filteredRecords.length){
+      statusEl.textContent = '表示できる記録がありません。';
+    }else{
+      statusEl.textContent = `${filteredRecords.length}件表示`;
+    }
+    return;
+  }
   if(!filteredRecords.length){
     if(searchValue){
       statusEl.textContent = `該当する記録はありません（キーワード「${searchValue}」）。`;
@@ -579,7 +678,7 @@ function fetchShareMeta(){
     return Promise.resolve(null);
   }
   setLoading('共有設定を確認しています…');
-  return callShareApi('meta', { token: externalToken }).then(res => {
+  return callShareApi('meta', { token: externalToken, recordId: resolvedRecordId }).then(res => {
     if(!res || res.status !== 'success'){
       const msg = res && res.message ? res.message : '共有設定の取得に失敗しました。';
       showAlert('error', msg);
@@ -592,16 +691,24 @@ function fetchShareMeta(){
     setIntro(share);
     setFooter(share);
     let normalizedRecords = [];
+    primaryRecordData = res.primaryRecord || (Array.isArray(res.records) ? res.records[0] : null);
+    if(!resolvedRecordId && primaryRecordData && primaryRecordData.recordId){
+      resolvedRecordId = String(primaryRecordData.recordId);
+    }
+    setSingleRecordMode(Boolean(resolvedRecordId));
     if(!share.requirePassword){
       normalizedRecords = normalizeRecords(Array.isArray(res.records) ? res.records : []);
       recordsCache = normalizedRecords;
       latestTimestamp = recordsCache.reduce((max, rec) => Math.max(max, Number(rec.timestamp||0)||0), 0) || null;
       updateKindOptions();
+      updatePrintControls(primaryRecordData);
     }else{
       recordsCache = [];
       latestTimestamp = null;
       updateKindOptions();
+      updatePrintControls(null);
     }
+    updateFilterVisibility();
     if(share.expired){
       showAlert('warning', 'この共有リンクは期限切れです。最新のリンクを発行してください。');
       setLoading('期限切れのため閲覧できません。');
@@ -619,7 +726,7 @@ function fetchShareMeta(){
 
 function loadShareData(password){
   setLoading('記録を読み込んでいます…');
-  return callShareApi('enter', { token: externalToken, password: password || '' }).then(res => {
+  return callShareApi('enter', { token: externalToken, password: password || '', recordId: resolvedRecordId }).then(res => {
     if(!res || res.status !== 'success'){
       const msg = res && res.message ? res.message : '閲覧に失敗しました。';
       showAlert('error', msg);
@@ -638,12 +745,17 @@ function loadShareData(password){
     setFooter(currentShare);
     const auth = document.getElementById('shareAuth');
     if(auth) auth.style.display = 'none';
-    const filters = document.getElementById('shareFilters');
-    if(filters) filters.style.display = 'flex';
+    primaryRecordData = res.primaryRecord || (Array.isArray(res.records) ? res.records[0] : primaryRecordData);
+    if(!resolvedRecordId && primaryRecordData && primaryRecordData.recordId){
+      resolvedRecordId = String(primaryRecordData.recordId);
+    }
+    setSingleRecordMode(Boolean(resolvedRecordId));
     showAlert(currentShare.expired ? 'warning' : '', currentShare.expired ? 'リンクの期限が切れています。再発行を依頼してください。' : '');
     recordsCache = normalizeRecords(Array.isArray(res.records) ? res.records : []);
     latestTimestamp = recordsCache.reduce((max, rec) => Math.max(max, Number(rec.timestamp||0)||0), 0) || null;
     updateKindOptions();
+    updateFilterVisibility();
+    updatePrintControls(primaryRecordData);
     applyQuickRange(getDefaultQuickRange(currentShare));
     if(!recordsCache.length){
       setLoading('共有可能な記録はまだありません。');
@@ -681,6 +793,8 @@ function initSharePage(){
   if(loadMore) loadMore.addEventListener('click', handleLoadMore);
   const authForm = document.getElementById('authForm');
   if(authForm) authForm.addEventListener('submit', onAuthSubmit);
+  const printButton = document.getElementById('printButton');
+  if(printButton) printButton.addEventListener('click', handlePrintClick);
 
   fetchShareMeta().then(result => {
     if(!result) return;
@@ -691,8 +805,8 @@ function initSharePage(){
       setLoading('パスワードを入力してください。');
       return;
     }
-    const filters = document.getElementById('shareFilters');
-    if(filters) filters.style.display = 'flex';
+    updateFilterVisibility();
+    updatePrintControls(primaryRecordData);
     showAlert(share.expired ? 'warning' : '', share.expired ? 'リンクの期限が切れています。再発行を依頼してください。' : '');
     if(share.expired){
       setLoading('期限切れのため閲覧できません。');


### PR DESCRIPTION
## Summary
- restrict external share responses to a specified record ID and expose record metadata for printing
- add helpers to fetch records by center or staff and reuse them in new print modes
- refresh share.html UI with single-record mode, print scope selector, and updated API calls
- redesign print.html to render printable record tables with optional center/staff aggregation context

## Testing
- No automated tests (Apps Script environment)
- Captured share page screenshot via local static preview

------
https://chatgpt.com/codex/tasks/task_e_68d796e2b6e88321a55a726f61e52e54