### PR TITLE
Ensure share API exposes QR metadata

### DIFF
--- a/share.html
+++ b/share.html
@@ -394,7 +394,31 @@ function pickFirstArray(...candidates){
 function resolveSharePayload(res){
   if(!res || typeof res !== 'object'){ return { share:null, records:[], report:null, primaryRecord:null, message:'', status:'' }; }
   const meta = res.meta && typeof res.meta === 'object' ? res.meta : null;
-  const share = res.share || (meta && meta.share) || null;
+  const baseShare = res.share || (meta && meta.share) || null;
+  const share = baseShare && typeof baseShare === 'object' ? { ...baseShare } : baseShare;
+  const mergeTargets = Array.isArray(share) || typeof share !== 'object' ? null : share;
+  if(mergeTargets){
+    const candidateSources = [res, meta];
+    const fields = ['qrEmbedUrl','qrDataUrl','qrDriveUrl','qrUrl','qrCode','shareLink','url'];
+    for(const field of fields){
+      const existing = mergeTargets[field];
+      if(typeof existing === 'string' && existing.trim()) continue;
+      for(const source of candidateSources){
+        if(source && typeof source === 'object' && field in source){
+          const value = source[field];
+          if(typeof value === 'string' && value.trim()){
+            mergeTargets[field] = value;
+            break;
+          }
+        }
+      }
+    }
+    if(!mergeTargets.shareLink && typeof mergeTargets.url === 'string' && mergeTargets.url.trim()){
+      mergeTargets.shareLink = mergeTargets.url;
+    }else if(!mergeTargets.url && typeof mergeTargets.shareLink === 'string' && mergeTargets.shareLink.trim()){
+      mergeTargets.url = mergeTargets.shareLink;
+    }
+  }
   const report = res.report || (meta && meta.report) || null;
   const records = pickFirstArray(res.records, res.rawRecords, meta && meta.records, meta && meta.rawRecords);
   const primaryRecord = res.primaryRecord || (meta && meta.primaryRecord) || (records.length ? records[0] : null);

--- a/コード.js
+++ b/コード.js
@@ -2322,6 +2322,10 @@ function shareBuildResponse_(share, recordId, includeRecords, includeReport) {
     recordCount: recordResult.records.length,
     report,
     qrUrl: summary.qrUrl,
+    qrEmbedUrl: summary.qrEmbedUrl,
+    qrDriveUrl: summary.qrDriveUrl,
+    qrDataUrl: summary.qrDataUrl,
+    qrCode: summary.qrCode,
     shareLink: summary.url
   };
 }
@@ -2352,7 +2356,13 @@ function getExternalShareMeta(token, recordId) {
       rawRecords: response.rawRecords || response.records,
       primaryRecord: response.primaryRecord,
       report: response.report,
-      message: includeRecords ? response.message : ''
+      message: includeRecords ? response.message : '',
+      qrUrl: response.qrUrl,
+      qrEmbedUrl: response.qrEmbedUrl,
+      qrDriveUrl: response.qrDriveUrl,
+      qrDataUrl: response.qrDataUrl,
+      qrCode: response.qrCode,
+      shareLink: response.shareLink
     };
   } catch (err) {
     Logger.log('❌ getExternalShareMeta failed: ' + (err && err.stack ? err.stack : err));
@@ -2394,7 +2404,13 @@ function enterExternalShare(token, password, recordId) {
       rawRecords: response.rawRecords || response.records,
       primaryRecord: response.primaryRecord,
       report: response.report,
-      message: response.message
+      message: response.message,
+      qrUrl: response.qrUrl,
+      qrEmbedUrl: response.qrEmbedUrl,
+      qrDriveUrl: response.qrDriveUrl,
+      qrDataUrl: response.qrDataUrl,
+      qrCode: response.qrCode,
+      shareLink: response.shareLink
     };
   } catch (err) {
     Logger.log('❌ enterExternalShare failed: ' + (err && err.stack ? err.stack : err));


### PR DESCRIPTION
## Summary
- return the generated QR code URLs from `shareBuildResponse_` through the share API responses
- merge QR-related fields from API responses back into the share payload on the client so the QR image can render

## Testing
- not run (Google Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcf7954d7883219414f5f10cedd631