### PR TITLE
Fix profile lookup for shared monitoring views

### DIFF
--- a/コード.js
+++ b/コード.js
@@ -2735,15 +2735,27 @@ function honobonoGetMasterMap_() {
   const map = new Map();
   for (let r = 1; r < values.length; r++) {
     const row = values[r];
-    const id = honobonoAt_(row, idx, HONOBONO_MEMBER_ID_HEADER);
-    if (!id) continue;
-    map.set(id, {
-      memberId: id,
+    const idRaw = honobonoAt_(row, idx, HONOBONO_MEMBER_ID_HEADER);
+    if (!idRaw) continue;
+
+    const normalizedId = normalizeMemberId_(idRaw);
+    const info = {
+      memberId: normalizedId || idRaw,
+      memberIdRaw: idRaw,
       name:  honobonoAt_(row, idx, HONOBONO_NAME_HEADER),
       kana:  honobonoAt_(row, idx, HONOBONO_KANA_HEADER),
       center:honobonoAt_(row, idx, HONOBONO_CENTER_HEADER),
       staff: honobonoAt_(row, idx, HONOBONO_STAFF_HEADER),
       qrUrl: honobonoAt_(row, idx, HONOBONO_QR_HEADER),
+    };
+
+    const keyCandidates = [];
+    if (idRaw) keyCandidates.push(idRaw);
+    if (normalizedId && normalizedId !== idRaw) keyCandidates.push(normalizedId);
+
+    keyCandidates.forEach(key => {
+      if (!key) return;
+      map.set(String(key), info);
     });
   }
   __honobonoCacheMap = map;
@@ -2753,7 +2765,17 @@ function honobonoGetMasterMap_() {
 /** IDで1件取得（無ければ null） */
 function honobonoFindById_(memberId) {
   const map = honobonoGetMasterMap_();
-  return map.get(String(memberId)) || null;
+  const directKey = String(memberId || '').trim();
+  if (directKey) {
+    const direct = map.get(directKey);
+    if (direct) return direct;
+  }
+  const normalized = normalizeMemberId_(memberId);
+  if (normalized) {
+    const normalizedHit = map.get(normalized);
+    if (normalizedHit) return normalizedHit;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- normalize Honobono ID keys when building the cached profile map
- try normalized IDs when resolving Honobono records so share metadata exposes member details

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcf7c60d088321ae978d81bef8bce2