### PR TITLE
Normalize monitoring dashboard status handling

### DIFF
--- a/member.html
+++ b/member.html
@@ -482,6 +482,12 @@ function getMemberStatusMeta(status) {
   return MEMBER_STATUS_META[key] || { label: key, icon: "" };
 }
 
+function normalizeDashboardEntry(entry) {
+  if (!entry || typeof entry !== "object") return entry;
+  const normalizedStatus = normalizeMemberStatusValue(entry.memberStatus || entry.status);
+  return { ...entry, memberStatus: normalizedStatus || MEMBER_STATUS_DEFAULT };
+}
+
 function getAudienceInfo(audience){
   const key = String(audience || "").toLowerCase();
   return shareAudienceInfo[key] || shareAudienceInfo[shareAudienceDefault];
@@ -1168,7 +1174,7 @@ function loadDashboard() {
       if (container) container.innerHTML = "";
       return;
     }
-    dashboardState.data = Array.isArray(res.data) ? res.data : [];
+    dashboardState.data = Array.isArray(res.data) ? res.data.map(normalizeDashboardEntry) : [];
     dashboardState.monthLabel = res.monthLabel || "";
     dashboardState.monthBadgeLabel = res.monthBadgeLabel || "";
     dashboardState.previousMonthLabel = res.previousMonthLabel || "";
@@ -1515,9 +1521,9 @@ async function updateDashboardMemberStatus(memberId, status) {
     }
     dashboardState.data = (Array.isArray(dashboardState.data) ? dashboardState.data : []).map(entry => {
       if (entry && entry.id === member) {
-        return { ...entry, memberStatus: normalizedStatus };
+        return normalizeDashboardEntry({ ...entry, memberStatus: normalizedStatus });
       }
-      return entry;
+      return normalizeDashboardEntry(entry);
     });
     renderDashboard();
   } catch (err) {

--- a/コード.js
+++ b/コード.js
@@ -550,6 +550,7 @@ function buildRecordFromRow_(row, header, indexes, tz, rowIndex){
   const centerValue = indexes.center >= 0 ? String(row[indexes.center] || '').trim() : '';
   const staffValue = indexes.staff >= 0 ? String(row[indexes.staff] || '').trim() : '';
   const statusValue = indexes.status >= 0 ? String(row[indexes.status] || '').trim() : '';
+  const normalizedStatusValue = normalizeMemberStatusValue_(statusValue);
   const specialValue = indexes.special >= 0 ? String(row[indexes.special] || '').trim() : '';
   let memberNameValue = indexes.memberName >= 0 ? String(row[indexes.memberName] || '').trim() : '';
   if (recordIdValue && !('recordId' in fields)) {
@@ -589,6 +590,7 @@ function buildRecordFromRow_(row, header, indexes, tz, rowIndex){
     center: centerValue,
     staff: staffValue,
     status: statusValue,
+    memberStatus: normalizedStatusValue || '',
     special: specialValue,
     fields
   };
@@ -905,6 +907,13 @@ function getDashboardSummary() {
       if (!id) continue;
       const entry = ensureEntry(id);
 
+      if (colStatus >= 0) {
+        const normalizedStatus = normalizeMemberStatusValue_(row[colStatus]);
+        if (normalizedStatus) {
+          entry.memberStatus = normalizedStatus;
+        }
+      }
+
       const rawDate = row[colDate];
       const d = (rawDate instanceof Date) ? rawDate : new Date(rawDate);
       if (!(d instanceof Date) || isNaN(d.getTime())) continue;
@@ -916,12 +925,6 @@ function getDashboardSummary() {
         entry.countThisMonth += 1;
       } else if (ts >= prevMonthStart.getTime() && ts <= prevMonthEnd.getTime()) {
         entry.countPreviousMonth += 1;
-      }
-      if (colStatus >= 0) {
-        const normalizedStatus = normalizeMemberStatusValue_(row[colStatus]);
-        if (normalizedStatus) {
-          entry.memberStatus = normalizedStatus;
-        }
       }
     }
 


### PR DESCRIPTION
## Summary
- normalize dashboard entries so member status changes are preserved locally and after reloads
- persist normalized status values when reading Monitoring sheet rows, even for status-only rows
- expose normalized status alongside record payloads for client use

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd481a584c8321a7edb8feb2c1f199