### PR TITLE
Adjust new member form field widths

### DIFF
--- a/member.html
+++ b/member.html
@@ -33,8 +33,8 @@ button:hover { opacity:0.9;}
 .member-top-card { display:flex; flex-direction:column; gap:12px; }
 .member-select-toolbar { position:relative; }
 .member-new-form { display:flex; flex-direction:column; gap:10px; }
-.member-new-row { display:grid; gap:10px 12px; grid-template-columns:repeat(2, minmax(160px, 1fr)); align-items:end; }
-.member-new-row.member-new-row--compact { grid-template-columns:minmax(90px, 140px) minmax(160px, 1fr); }
+.member-new-row { display:grid; gap:10px 12px; grid-template-columns:repeat(2, minmax(120px, 1fr)); align-items:end; }
+.member-new-row.member-new-row--compact { grid-template-columns:minmax(70px, 100px) minmax(120px, 160px); }
 .member-new-row.member-new-row--actions { grid-template-columns:minmax(200px, 1fr) auto; align-items:center; }
 .member-new-form input,
 .member-new-form select { width:100%; }


### PR DESCRIPTION
## Summary
- narrow the desktop layout of the new member form fields so ID and担当者 inputs take up less width
- adjust the default two-column grid to use a tighter min width while retaining 100% width on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddc44c67388321ad30f113cdd8a47c