### PR TITLE
Fix autocomplete click handling in member search

### DIFF
--- a/member.html
+++ b/member.html
@@ -1738,9 +1738,27 @@ function setupSearchBox() {
   input.addEventListener("change", resolveInput);
   listBox.addEventListener("click", e => {
     const rawTarget = e.target;
-    const item = rawTarget instanceof Element
-      ? rawTarget.closest(".autocomplete-item")
-      : (rawTarget && rawTarget.parentElement ? rawTarget.parentElement.closest(".autocomplete-item") : null);
+    let item = null;
+
+    if (rawTarget && typeof rawTarget.closest === "function") {
+      item = rawTarget.closest(".autocomplete-item");
+    }
+
+    if (!item && rawTarget && rawTarget.parentElement && typeof rawTarget.parentElement.closest === "function") {
+      item = rawTarget.parentElement.closest(".autocomplete-item");
+    }
+
+    if (!item) {
+      let cursor = rawTarget && rawTarget.parentElement ? rawTarget.parentElement : null;
+      while (cursor && cursor !== listBox) {
+        if (cursor.classList && cursor.classList.contains("autocomplete-item")) {
+          item = cursor;
+          break;
+        }
+        cursor = cursor.parentElement;
+      }
+    }
+
     if (!item || item.dataset.empty === "true") return;
 
     const dataset = item.dataset;


### PR DESCRIPTION
## Summary
- update the member search autocomplete click handler to reliably resolve the clicked item
- add fallbacks to traverse parent elements so the correct candidate is selected

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de737f04388321b4018d39989fcfb2