### PR TITLE
Add spreadsheet billing aggregation menu and helpers

### DIFF
--- a/コード.js
+++ b/コード.js
@@ -39,6 +39,16 @@ const ATTACHMENTS_FOLDER_ID_PROP= DEFAULT_FOLDER_ID;
 const DOC_TEMPLATE_ID_PROP        = PropertiesService.getScriptProperties().getProperty('DOC_TEMPLATE_ID') || '';
 const DOC_TEMPLATE_ID_FAMILY_PROP = PropertiesService.getScriptProperties().getProperty('DOC_TEMPLATE_ID_FAMILY') || '';
 
+const BILLING_TREATMENT_SHEET_NAME = '施術録';
+const BILLING_HEADER_ALIASES = {
+  recordId: ['施術録番号', '施術番号', '利用者番号', '利用者ID', 'ID', 'No', '番号'],
+  patientName: ['患者様氏名', '患者名', '利用者名', '氏名', '名前'],
+  treatmentDate: ['施術日', '日付', '実施日', '対応日', '記録日'],
+  burdenRatio: ['負担割合', '負担率', '自己負担', '自己負担割合'],
+  treatmentCount: ['施術回数', '回数', '利用回数'],
+  amount: ['請求額', '請求金額', '金額', '支払額', '負担金額', '合計金額', '単価']
+};
+
 /** パラメータの余計な " を除去するユーティリティ */
 function cleanParam_(value) {
   return String(value || "")
@@ -3359,4 +3369,334 @@ function convertFullWidthToHalfWidth() {
   });
 
   range.setValues(converted);
+}
+
+function onOpen() {
+  const ui = SpreadsheetApp.getUi();
+  ui.createMenu('請求集計')
+    .addItem('請求月を指定して集計', 'showBillingAggregationPrompt')
+    .addToUi();
+}
+
+function showBillingAggregationPrompt() {
+  const ui = SpreadsheetApp.getUi();
+  try {
+    const month = promptBillingMonth_(ui);
+    if (!month) {
+      return;
+    }
+    const result = aggregateBillingForMonth(month);
+    ui.alert(
+      '請求集計が完了しました',
+      `シート「${result.sheetName}」に ${result.totalRecords} 件の集計結果を出力しました。`,
+      ui.ButtonSet.OK
+    );
+  } catch (error) {
+    Logger.log('Billing aggregation failed: ' + (error && error.stack ? error.stack : error));
+    ui.alert('請求集計でエラーが発生しました', String(error && error.message ? error.message : error), ui.ButtonSet.OK);
+  }
+}
+
+function promptBillingMonth_(ui) {
+  while (true) {
+    const response = ui.prompt(
+      '請求月を指定して集計',
+      '対象月 (YYYY-MM) を入力してください。',
+      ui.ButtonSet.OK_CANCEL
+    );
+    const button = response.getSelectedButton();
+    if (button !== ui.Button.OK) {
+      return null;
+    }
+    const text = (response.getResponseText() || '').trim();
+    if (!text) {
+      ui.alert('入力が空です。YYYY-MM 形式で入力してください。');
+      continue;
+    }
+    if (!isValidYearMonthFormat_(text)) {
+      ui.alert('入力形式が正しくありません。YYYY-MM 形式で入力してください。');
+      continue;
+    }
+    return text;
+  }
+}
+
+function isValidYearMonthFormat_(value) {
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(String(value || '').trim());
+}
+
+function aggregateBillingForMonth(yearMonth) {
+  const calculation = calculateBillingForMonth(yearMonth);
+  const ss = SpreadsheetApp.getActiveSpreadsheet() || SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheetName = `請求集計_${yearMonth.replace('-', '')}`;
+  let sheet = ss.getSheetByName(sheetName);
+  if (!sheet) {
+    sheet = ss.insertSheet(sheetName);
+  } else {
+    sheet.clearContents();
+    sheet.clearFormats();
+  }
+
+  const headers = ['施術録番号', '患者様氏名', '合計施術回数', '負担割合', '請求金額'];
+  const rows = calculation.records.map(record => [
+    record.recordId || '',
+    record.patientName || '',
+    record.treatmentCount || 0,
+    record.burdenRatioDisplay || '',
+    record.billingAmount !== null && record.billingAmount !== undefined ? record.billingAmount : ''
+  ]);
+
+  const values = [headers, ...rows];
+  sheet.getRange(1, 1, values.length, headers.length).setValues(values);
+  sheet.setFrozenRows(1);
+  if (rows.length > 0) {
+    sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
+    sheet.getRange(2, 3, rows.length, 1).setNumberFormat('0');
+    sheet.getRange(2, 5, rows.length, 1).setNumberFormat('#,##0');
+  }
+  sheet.autoResizeColumns(1, headers.length);
+
+  return {
+    sheetName,
+    totalRecords: rows.length,
+    month: yearMonth
+  };
+}
+
+function calculateBillingForMonth(yearMonth) {
+  if (!isValidYearMonthFormat_(yearMonth)) {
+    throw new Error('YYYY-MM 形式の月を指定してください。');
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet() || SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ss.getSheetByName(BILLING_TREATMENT_SHEET_NAME);
+  if (!sheet) {
+    throw new Error(`シート『${BILLING_TREATMENT_SHEET_NAME}』が見つかりません。`);
+  }
+
+  const values = sheet.getDataRange().getValues();
+  if (!values || values.length < 2) {
+    return { month: yearMonth, records: [] };
+  }
+
+  const headers = values[0].map(header => (header || '').toString().trim());
+  const indexes = Object.keys(BILLING_HEADER_ALIASES).reduce((acc, key) => {
+    const aliases = BILLING_HEADER_ALIASES[key];
+    acc[key] = findHeaderIndex_(headers, aliases);
+    return acc;
+  }, {});
+
+  if (indexes.treatmentDate === -1) {
+    throw new Error('シートに「施術日」に該当する列が見つかりません。');
+  }
+
+  const map = {};
+  const timezone = Session.getScriptTimeZone() || 'Asia/Tokyo';
+  const amountHeaderLabel = indexes.amount >= 0 ? headers[indexes.amount] : '';
+  const amountLabelNormalized = toStringSafe_(amountHeaderLabel).toLowerCase();
+  const treatAmountAsUnit = amountLabelNormalized
+    ? /単価|単位|1回|一回|回単価|単位金額|日額|時間単価/.test(amountLabelNormalized)
+    : false;
+  const treatAmountAsFinal = amountLabelNormalized
+    ? /請求|負担|金額|支払|合計/.test(amountLabelNormalized)
+    : false;
+
+  for (let rowIndex = 1; rowIndex < values.length; rowIndex++) {
+    const row = values[rowIndex];
+    const month = getYearMonthFromValue_(row[indexes.treatmentDate], timezone);
+    if (month !== yearMonth) {
+      continue;
+    }
+
+    const recordId = indexes.recordId >= 0 ? toStringSafe_(row[indexes.recordId]) : '';
+    const patientName = indexes.patientName >= 0 ? toStringSafe_(row[indexes.patientName]) : '';
+    if (!recordId && !patientName) {
+      continue;
+    }
+
+    const key = recordId || patientName;
+    if (!map[key]) {
+      map[key] = {
+        recordId,
+        patientName,
+        treatmentCount: 0,
+        burdenRatio: null,
+        billingAmount: 0,
+        hasAmount: false
+      };
+    } else {
+      if (recordId && !map[key].recordId) {
+        map[key].recordId = recordId;
+      }
+      if (patientName && !map[key].patientName) {
+        map[key].patientName = patientName;
+      }
+    }
+
+    const countValue = indexes.treatmentCount >= 0 ? parseNumber_(row[indexes.treatmentCount]) : null;
+    const amountValue = indexes.amount >= 0 ? parseNumber_(row[indexes.amount]) : null;
+    const burdenRatio = indexes.burdenRatio >= 0 ? normalizeBurdenRatio_(row[indexes.burdenRatio]) : null;
+
+    const count = countValue !== null && !isNaN(countValue) && countValue > 0 ? countValue : 1;
+    map[key].treatmentCount += count;
+
+    if (burdenRatio !== null) {
+      map[key].burdenRatio = burdenRatio;
+    }
+
+    if (amountValue !== null && !isNaN(amountValue)) {
+      let rowAmount = amountValue;
+      if (treatAmountAsUnit) {
+        const ratioToApply = map[key].burdenRatio !== null ? map[key].burdenRatio : (burdenRatio !== null ? burdenRatio : 1);
+        rowAmount = amountValue * (ratioToApply || 0);
+        rowAmount *= count;
+      } else if (!treatAmountAsFinal && count > 1) {
+        rowAmount *= count;
+      }
+
+      if (!isNaN(rowAmount)) {
+        map[key].billingAmount += rowAmount;
+        map[key].hasAmount = true;
+      }
+    }
+  }
+
+  const records = Object.values(map).map(entry => ({
+    recordId: entry.recordId,
+    patientName: entry.patientName,
+    treatmentCount: entry.treatmentCount,
+    burdenRatio: entry.burdenRatio,
+    burdenRatioDisplay: formatRatioDisplay_(entry.burdenRatio),
+    billingAmount: entry.hasAmount ? entry.billingAmount : null
+  })).sort((a, b) => {
+    const nameA = a.patientName || '';
+    const nameB = b.patientName || '';
+    const nameCompare = nameA.localeCompare(nameB, 'ja');
+    if (nameCompare !== 0) {
+      return nameCompare;
+    }
+    const idA = (a.recordId || '').toString();
+    const idB = (b.recordId || '').toString();
+    return idA.localeCompare(idB, 'ja');
+  });
+
+  return {
+    month: yearMonth,
+    records
+  };
+}
+
+function findHeaderIndex_(headers, aliases) {
+  if (!Array.isArray(headers) || !Array.isArray(aliases)) {
+    return -1;
+  }
+  for (let i = 0; i < headers.length; i++) {
+    const header = headers[i];
+    if (!header) {
+      continue;
+    }
+    const normalized = header.toString().trim();
+    if (!normalized) {
+      continue;
+    }
+    if (aliases.some(alias => alias.toLowerCase() === normalized.toLowerCase())) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function getYearMonthFromValue_(value, timezone) {
+  if (value instanceof Date) {
+    return Utilities.formatDate(value, timezone, 'yyyy-MM');
+  }
+  const text = toStringSafe_(value);
+  if (!text) {
+    return '';
+  }
+  const normalized = text
+    .replace(/[年月]/g, '-')
+    .replace(/日/g, '')
+    .replace(/[\.\/]/g, '-')
+    .replace(/--+/g, '-');
+  const match = normalized.match(/(\d{4})-(\d{1,2})/);
+  if (!match) {
+    return '';
+  }
+  const month = match[2].length === 1 ? `0${match[2]}` : match[2];
+  return `${match[1]}-${month}`;
+}
+
+function toStringSafe_(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function parseNumber_(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  if (typeof value === 'number') {
+    return isNaN(value) ? null : value;
+  }
+  const text = String(value)
+    .replace(/[\s,円￥]/g, '')
+    .replace(/[(（].*[)）]/g, '')
+    .trim();
+  if (!text) {
+    return null;
+  }
+  const number = Number(text);
+  return isNaN(number) ? null : number;
+}
+
+function normalizeBurdenRatio_(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  if (typeof value === 'number') {
+    if (value > 1) {
+      return value / 100;
+    }
+    return value;
+  }
+  const text = String(value).trim();
+  if (!text) {
+    return null;
+  }
+  if (text.includes('%')) {
+    const num = parseFloat(text.replace('%', ''));
+    return isNaN(num) ? null : num / 100;
+  }
+  if (text.includes('割')) {
+    const num = parseFloat(text.replace('割', ''));
+    return isNaN(num) ? null : num / 10;
+  }
+  const num = parseFloat(text);
+  if (isNaN(num)) {
+    return null;
+  }
+  if (num > 1) {
+    if (num === 10) {
+      return 0.1;
+    }
+    if (num <= 10) {
+      return num / 10;
+    }
+    if (num <= 100) {
+      return num / 100;
+    }
+    return num / 100;
+  }
+  return num;
+}
+
+function formatRatioDisplay_(ratio) {
+  if (ratio === null || ratio === undefined || isNaN(ratio)) {
+    return '';
+  }
+  const percent = ratio * 100;
+  return Number.isInteger(percent) ? `${percent}%` : `${percent.toFixed(1)}%`;
 }


### PR DESCRIPTION
## Summary
- add a custom "請求集計" spreadsheet menu that prompts for a billing month and triggers aggregation
- implement billing aggregation that summarizes the "施術録" sheet into a monthly 請求集計_YYYYMM sheet with counts and amounts
- add helper utilities to resolve sheet headers and normalize burden ratios and numeric values

## Testing
- not run (Apps Script only)


------
https://chatgpt.com/codex/tasks/task_e_68df84f5739c8321a6aba0ebca5d04e5